### PR TITLE
feat: add Yarn and pnpm cache providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,23 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15
         with:
           command: check advisories licenses bans sources
+
+  e2e-js-providers:
+    name: E2E JS Provider Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install Yarn Classic
+        run: npm install -g yarn@1
+
+      - name: Enable Corepack (for Yarn Berry)
+        run: corepack enable
+
+      - name: Run E2E tests
+        run: cargo test --features e2e --test e2e_js_providers -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
     name: E2E JS Provider Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/superpowers/
 .mcp.json
 demo.tape
 REVIEW-*.md
+.worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ assets = [
 
 [features]
 default = []
+e2e = []
 mcp = ["dep:rmcp", "dep:tokio", "dep:schemars", "dep:tracing-subscriber"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 - **Bulk mark** — `m` marks all visible (non-dimmed) items after filtering
 - **Workflow**: scan (`V`) → filter (`f`) → mark all (`m`) → delete (`d`)
 
+## Platform Support
+
+**macOS and Linux only.** Windows is not supported. Path detection, cache directory resolution, and provider logic all assume Unix-style paths.
+
 ## Supported Caches
 
 | Provider | Location | Semantic names |

--- a/docs/superpowers/plans/2026-04-08-yarn-pnpm-providers.md
+++ b/docs/superpowers/plans/2026-04-08-yarn-pnpm-providers.md
@@ -1,0 +1,2024 @@
+# Yarn & pnpm Providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Yarn (Classic + Berry) and pnpm cache providers to cache-explorer, with full package identification, vulnerability scanning, and auto-detection of cache paths.
+
+**Architecture:** Two new provider modules (`yarn.rs`, `pnpm.rs`) following the existing dispatch pattern. Each implements `detect`, `semantic_name`, `metadata`, and `package_id` functions. The `CacheKind` enum gains two variants. Auto-detection probes CLI tools at startup to discover cache paths.
+
+**Tech Stack:** Rust, `std::process::Command` for CLI probing, `tempfile` for tests, real `yarn`/`pnpm` CLI for E2E tests.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `src/tree/node.rs` | Add `Yarn`, `Pnpm` variants to `CacheKind` enum with label/description/url |
+| `src/providers/mod.rs` | Module declarations, dispatch match arms for all 5 functions + safety |
+| `src/providers/yarn.rs` | **New** — Yarn 1 + Berry detection, naming, metadata, package_id |
+| `src/providers/pnpm.rs` | **New** — pnpm store + virtual store detection, naming, metadata, package_id |
+| `src/config.rs` | Auto-detection of Yarn/pnpm cache paths via CLI probing + fallback paths |
+| `Cargo.toml` | Add `e2e` feature flag |
+| `tests/integration.rs` | Yarn/pnpm fixture-based integration tests |
+| `tests/e2e_js_providers.rs` | **New** — E2E tests with real Yarn/pnpm tools |
+| `.github/workflows/ci.yml` | Add E2E test job |
+
+---
+
+### Task 1: Add CacheKind Variants
+
+**Files:**
+- Modify: `src/tree/node.rs:5-76`
+
+- [ ] **Step 1: Write failing test for Yarn CacheKind**
+
+Add to the existing test module in `src/tree/node.rs` (after line 196):
+
+```rust
+#[test]
+fn cache_kind_yarn_has_label() {
+    assert_eq!(CacheKind::Yarn.label(), "Yarn");
+    assert!(!CacheKind::Yarn.description().is_empty());
+    assert!(!CacheKind::Yarn.url().is_empty());
+}
+
+#[test]
+fn cache_kind_pnpm_has_label() {
+    assert_eq!(CacheKind::Pnpm.label(), "pnpm");
+    assert!(!CacheKind::Pnpm.description().is_empty());
+    assert!(!CacheKind::Pnpm.url().is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --lib tree::node::tests::cache_kind_yarn_has_label 2>&1 | tail -5`
+Expected: Compilation error — `Yarn` is not a variant of `CacheKind`
+
+- [ ] **Step 3: Add Yarn and Pnpm to CacheKind enum**
+
+In `src/tree/node.rs`, add `Yarn` and `Pnpm` before `Unknown` in the enum (line 17):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CacheKind {
+    HuggingFace,
+    Pip,
+    Uv,
+    Npm,
+    Homebrew,
+    Cargo,
+    PreCommit,
+    Whisper,
+    Gh,
+    Torch,
+    Chroma,
+    Prisma,
+    Yarn,
+    Pnpm,
+    #[default]
+    Unknown,
+}
+```
+
+Add to `label()` match (after `Prisma` arm, before `Unknown`):
+
+```rust
+Self::Yarn => "Yarn",
+Self::Pnpm => "pnpm",
+```
+
+Add to `description()` match:
+
+```rust
+Self::Yarn => "Yarn package manager — cached packages and metadata",
+Self::Pnpm => "pnpm package manager — content-addressed package store",
+```
+
+Add to `url()` match:
+
+```rust
+Self::Yarn => "https://yarnpkg.com",
+Self::Pnpm => "https://pnpm.io",
+```
+
+- [ ] **Step 4: Fix compilation errors in mod.rs dispatch functions**
+
+The existing match arms in `src/providers/mod.rs` need `Yarn` and `Pnpm` cases. Add temporary pass-through arms to each dispatch function so the project compiles:
+
+In `detect()` — no change needed (Yarn/Pnpm detection comes in Task 3).
+
+In `semantic_name()` (after line 117, before `CacheKind::Unknown`):
+
+```rust
+CacheKind::Yarn => None,
+CacheKind::Pnpm => None,
+```
+
+In `metadata()` (after line 136, before `CacheKind::Unknown`):
+
+```rust
+CacheKind::Yarn => generic::metadata(path),
+CacheKind::Pnpm => generic::metadata(path),
+```
+
+In `safety()` — no change needed (the `_ => SafetyLevel::Safe` wildcard covers new kinds).
+
+In `upgrade_command()` — no change needed (the `_ => None` wildcard covers new kinds).
+
+In `package_id()` — no change needed (the `_ => None` wildcard covers new kinds).
+
+Also add `Yarn` and `Pnpm` to the safety test's known providers list in `src/providers/mod.rs` (line 330):
+
+```rust
+assert_eq!(safety(CacheKind::Yarn, &path), SafetyLevel::Safe);
+assert_eq!(safety(CacheKind::Pnpm, &path), SafetyLevel::Safe);
+```
+
+And add to the `upgrade_command_unsupported_kinds_return_none` test (line 408):
+
+```rust
+let unsupported = [
+    CacheKind::HuggingFace,
+    CacheKind::Homebrew,
+    CacheKind::PreCommit,
+    CacheKind::Whisper,
+    CacheKind::Gh,
+    CacheKind::Torch,
+    CacheKind::Chroma,
+    CacheKind::Prisma,
+    CacheKind::Yarn,
+    CacheKind::Pnpm,
+];
+```
+
+- [ ] **Step 5: Run tests to verify everything passes**
+
+Run: `cargo test 2>&1 | tail -5`
+Expected: All tests pass, including the two new CacheKind tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tree/node.rs src/providers/mod.rs
+git commit -m "feat: add Yarn and Pnpm CacheKind variants"
+```
+
+---
+
+### Task 2: Yarn Provider — Detection & Semantic Names
+
+**Files:**
+- Create: `src/providers/yarn.rs`
+- Modify: `src/providers/mod.rs:1-13` (module declaration)
+
+- [ ] **Step 1: Create yarn.rs with failing unit tests for detection helpers**
+
+Create `src/providers/yarn.rs`:
+
+```rust
+use super::MetadataField;
+use std::path::Path;
+
+/// Identify whether a path is inside a Yarn cache.
+/// Returns true for both Yarn Classic and Berry cache structures.
+pub fn is_yarn_cache(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    // Yarn 1 Classic global caches
+    path_str.contains(".yarn-cache")
+        || path_str.contains(".cache/yarn")
+        || path_str.contains("Library/Caches/Yarn")
+        // Yarn 2+ Berry per-project cache
+        || path_str.contains(".yarn/cache")
+        // Yarn Berry global cache
+        || path_str.contains("yarn/berry/cache")
+}
+
+/// Determine if this path is inside a Yarn Berry (2+) cache.
+fn is_berry(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains(".yarn/cache") || path_str.contains("berry/cache")
+}
+
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Known directory names
+    match name.as_str() {
+        "cache" => {
+            if is_berry(path) {
+                return Some("Yarn Berry Cache".to_string());
+            }
+            return Some("Yarn Cache".to_string());
+        }
+        ".yarn-cache" => return Some("Yarn Classic Cache".to_string()),
+        _ => {}
+    }
+
+    // Berry zip: <name>-npm-<version>-<hash>.zip
+    if name.ends_with(".zip") {
+        if let Some((pkg_name, version)) = parse_berry_filename(&name) {
+            return Some(format!("{pkg_name} {version}"));
+        }
+    }
+
+    // Classic tgz: npm-<name>-<version>-<hash>.tgz
+    if name.ends_with(".tgz") {
+        if let Some((pkg_name, version)) = parse_classic_filename(&name) {
+            return Some(format!("{pkg_name} {version}"));
+        }
+    }
+
+    None
+}
+
+/// Parse a Yarn Berry (2+) cache filename.
+/// Format: `<name>-npm-<version>-<hash>.zip`
+/// Scoped: `@scope-name-npm-<version>-<hash>.zip`
+fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
+    let stem = filename.strip_suffix(".zip")?;
+    // Split on "-npm-" to separate package name from version-hash
+    let idx = stem.find("-npm-")?;
+    let raw_name = &stem[..idx];
+    let rest = &stem[idx + 5..]; // skip "-npm-"
+
+    // rest is "<version>-<hash>" — version ends before the last hyphen-hex segment
+    let version = extract_version_before_hash(rest)?;
+
+    // Convert scoped package names: "@scope-name" -> "@scope/name"
+    let pkg_name = normalize_scoped_name(raw_name);
+
+    Some((pkg_name, version))
+}
+
+/// Parse a Yarn Classic (1.x) cache filename.
+/// Format: `npm-<name>-<version>-<hash>.tgz`
+/// Scoped: `npm-@scope-name-<version>-<hash>.tgz`
+fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
+    let stem = filename.strip_suffix(".tgz")?;
+    let rest = stem.strip_prefix("npm-")?;
+
+    // For scoped packages like "@scope-name-1.0.0-hash",
+    // find the version by looking for "-<digit>" pattern
+    let (raw_name, version) = split_name_version(rest)?;
+    let pkg_name = normalize_scoped_name(&raw_name);
+
+    Some((pkg_name, version))
+}
+
+/// Given "name-1.2.3-hash", split into ("name", "1.2.3").
+/// Handles scoped: "@scope-name-1.2.3-hash" -> ("@scope-name", "1.2.3")
+fn split_name_version(s: &str) -> Option<(String, String)> {
+    // Walk through hyphen-separated segments.
+    // The version starts at the first segment beginning with a digit.
+    // The hash is the last segment (hex characters).
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    // Find first part that starts with a digit — that's the version start
+    let version_start = parts
+        .iter()
+        .position(|p| p.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false))?;
+
+    if version_start == 0 {
+        return None; // No name portion
+    }
+
+    let name = parts[..version_start].join("-");
+    // Version is everything between version_start and the last segment (hash)
+    let version = parts[version_start..parts.len() - 1].join("-");
+
+    if version.is_empty() {
+        return None;
+    }
+
+    Some((name, version))
+}
+
+/// Extract version from "1.2.3-<hash>" — everything before the last hyphen segment
+/// that is all hex characters (the integrity hash).
+fn extract_version_before_hash(s: &str) -> Option<String> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    // Last segment is the hash (hex chars). Walk backward to find where hash starts.
+    // Hash segments are typically 10+ hex chars.
+    let mut hash_start = parts.len();
+    for i in (0..parts.len()).rev() {
+        if parts[i].len() >= 8 && parts[i].chars().all(|c| c.is_ascii_hexdigit()) {
+            hash_start = i;
+        } else {
+            break;
+        }
+    }
+
+    if hash_start == 0 {
+        return None;
+    }
+
+    let version = parts[..hash_start].join("-");
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
+}
+
+/// Convert "@scope-name" to "@scope/name" for scoped npm packages.
+fn normalize_scoped_name(name: &str) -> String {
+    if name.starts_with('@') {
+        // First hyphen after @ is the scope separator
+        if let Some(pos) = name[1..].find('-') {
+            return format!("@{}/{}", &name[1..1 + pos], &name[2 + pos..]);
+        }
+    }
+    name.to_string()
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}
+
+pub fn package_id(_path: &Path) -> Option<super::PackageId> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- is_yarn_cache ---
+
+    #[test]
+    fn detects_classic_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from("/home/user/.yarn-cache/v6")));
+    }
+
+    #[test]
+    fn detects_classic_xdg_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from("/home/user/.cache/yarn/v6")));
+    }
+
+    #[test]
+    fn detects_berry_per_project_cache() {
+        assert!(is_yarn_cache(&PathBuf::from(
+            "/projects/myapp/.yarn/cache"
+        )));
+    }
+
+    #[test]
+    fn detects_macos_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from(
+            "/Users/me/Library/Caches/Yarn/v6"
+        )));
+    }
+
+    #[test]
+    fn does_not_detect_unrelated_path() {
+        assert!(!is_yarn_cache(&PathBuf::from("/home/user/.npm/_cacache")));
+    }
+
+    // --- Berry filename parsing ---
+
+    #[test]
+    fn parse_berry_simple_package() {
+        let (name, ver) = parse_berry_filename("lodash-npm-4.17.21-6382d821f21d.zip").unwrap();
+        assert_eq!(name, "lodash");
+        assert_eq!(ver, "4.17.21");
+    }
+
+    #[test]
+    fn parse_berry_scoped_package() {
+        let (name, ver) =
+            parse_berry_filename("@babel-core-npm-7.24.0-abc123def456.zip").unwrap();
+        assert_eq!(name, "@babel/core");
+        assert_eq!(ver, "7.24.0");
+    }
+
+    #[test]
+    fn parse_berry_prerelease_version() {
+        let (name, ver) =
+            parse_berry_filename("typescript-npm-5.0.0-beta.1-aabbccdd0011.zip").unwrap();
+        assert_eq!(name, "typescript");
+        assert_eq!(ver, "5.0.0-beta.1");
+    }
+
+    #[test]
+    fn parse_berry_invalid_no_npm_marker() {
+        assert!(parse_berry_filename("lodash-4.17.21.zip").is_none());
+    }
+
+    // --- Classic filename parsing ---
+
+    #[test]
+    fn parse_classic_simple_package() {
+        let (name, ver) =
+            parse_classic_filename("npm-lodash-4.17.21-6382d821f21d.tgz").unwrap();
+        assert_eq!(name, "lodash");
+        assert_eq!(ver, "4.17.21");
+    }
+
+    #[test]
+    fn parse_classic_scoped_package() {
+        let (name, ver) =
+            parse_classic_filename("npm-@babel-core-7.24.0-abc123def456.tgz").unwrap();
+        assert_eq!(name, "@babel/core");
+        assert_eq!(ver, "7.24.0");
+    }
+
+    #[test]
+    fn parse_classic_hyphenated_name() {
+        let (name, ver) =
+            parse_classic_filename("npm-is-even-1.0.0-aabb112233cc.tgz").unwrap();
+        assert_eq!(name, "is-even");
+        assert_eq!(ver, "1.0.0");
+    }
+
+    #[test]
+    fn parse_classic_invalid_no_npm_prefix() {
+        assert!(parse_classic_filename("lodash-4.17.21-hash.tgz").is_none());
+    }
+
+    // --- semantic_name ---
+
+    #[test]
+    fn semantic_name_berry_zip() {
+        let path = PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-6382d821f21d.zip");
+        assert_eq!(semantic_name(&path), Some("lodash 4.17.21".into()));
+    }
+
+    #[test]
+    fn semantic_name_classic_tgz() {
+        let path = PathBuf::from("/home/.yarn-cache/v6/npm-express-4.21.0-abcdef123456.tgz");
+        assert_eq!(semantic_name(&path), Some("express 4.21.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_cache_dir_berry() {
+        let path = PathBuf::from("/project/.yarn/cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Berry Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_cache_dir_classic() {
+        let path = PathBuf::from("/home/.cache/yarn/cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_yarn_cache_dir() {
+        let path = PathBuf::from("/home/.yarn-cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Classic Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_unknown_file() {
+        let path = PathBuf::from("/project/.yarn/cache/random.txt");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    // --- normalize_scoped_name ---
+
+    #[test]
+    fn normalize_scoped() {
+        assert_eq!(normalize_scoped_name("@babel-core"), "@babel/core");
+    }
+
+    #[test]
+    fn normalize_unscoped() {
+        assert_eq!(normalize_scoped_name("lodash"), "lodash");
+    }
+
+    #[test]
+    fn normalize_scoped_deep() {
+        assert_eq!(normalize_scoped_name("@types-node"), "@types/node");
+    }
+}
+```
+
+- [ ] **Step 2: Add module declaration to mod.rs**
+
+In `src/providers/mod.rs`, add after line 8 (`pub mod npm;`):
+
+```rust
+pub mod yarn;
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test --lib providers::yarn::tests 2>&1 | tail -10`
+Expected: All yarn unit tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/providers/yarn.rs src/providers/mod.rs
+git commit -m "feat: add Yarn provider with detection and semantic names"
+```
+
+---
+
+### Task 3: Yarn Provider — Package ID & Metadata
+
+**Files:**
+- Modify: `src/providers/yarn.rs`
+
+- [ ] **Step 1: Write failing tests for package_id**
+
+Add to the test module in `src/providers/yarn.rs`:
+
+```rust
+// --- package_id ---
+
+#[test]
+fn package_id_berry_zip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().join(".yarn/cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    let zip_file = cache.join("lodash-npm-4.17.21-6382d821f21d.zip");
+    std::fs::write(&zip_file, "fake zip").unwrap();
+
+    let id = package_id(&zip_file).unwrap();
+    assert_eq!(id.ecosystem, "npm");
+    assert_eq!(id.name, "lodash");
+    assert_eq!(id.version, "4.17.21");
+}
+
+#[test]
+fn package_id_classic_tgz() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().join(".yarn-cache/v6");
+    std::fs::create_dir_all(&cache).unwrap();
+    let tgz_file = cache.join("npm-express-4.21.0-abcdef123456.tgz");
+    std::fs::write(&tgz_file, "fake tgz").unwrap();
+
+    let id = package_id(&tgz_file).unwrap();
+    assert_eq!(id.ecosystem, "npm");
+    assert_eq!(id.name, "express");
+    assert_eq!(id.version, "4.21.0");
+}
+
+#[test]
+fn package_id_scoped_berry() {
+    let path = PathBuf::from("/project/.yarn/cache/@types-node-npm-22.0.0-aabb112233cc.zip");
+    let id = package_id(&path).unwrap();
+    assert_eq!(id.name, "@types/node");
+    assert_eq!(id.version, "22.0.0");
+}
+
+#[test]
+fn package_id_non_package_file() {
+    let path = PathBuf::from("/project/.yarn/cache/.gitignore");
+    assert!(package_id(&path).is_none());
+}
+
+#[test]
+fn package_id_directory_returns_none() {
+    let path = PathBuf::from("/project/.yarn/cache");
+    assert!(package_id(&path).is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib providers::yarn::tests::package_id_berry_zip 2>&1 | tail -5`
+Expected: FAIL — `package_id` currently returns `None` always.
+
+- [ ] **Step 3: Implement package_id**
+
+Replace the stub `package_id` in `src/providers/yarn.rs`:
+
+```rust
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Berry zip files
+    if name.ends_with(".zip") {
+        let (pkg_name, version) = parse_berry_filename(&name)?;
+        return Some(super::PackageId {
+            ecosystem: "npm",
+            name: pkg_name,
+            version,
+        });
+    }
+
+    // Classic tgz files
+    if name.ends_with(".tgz") {
+        let (pkg_name, version) = parse_classic_filename(&name)?;
+        return Some(super::PackageId {
+            ecosystem: "npm",
+            name: pkg_name,
+            version,
+        });
+    }
+
+    None
+}
+```
+
+- [ ] **Step 4: Implement metadata**
+
+Replace the stub `metadata` in `src/providers/yarn.rs`:
+
+```rust
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if name.ends_with(".zip") {
+        fields.push(MetadataField {
+            label: "Format".to_string(),
+            value: "Yarn Berry (.zip)".to_string(),
+        });
+    } else if name.ends_with(".tgz") {
+        fields.push(MetadataField {
+            label: "Format".to_string(),
+            value: "Yarn Classic (.tgz)".to_string(),
+        });
+    } else if name == "cache" || name == ".yarn-cache" {
+        // Cache root directory — count packages
+        if let Ok(entries) = std::fs::read_dir(path) {
+            let count = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    let n = e.file_name().to_string_lossy().to_string();
+                    n.ends_with(".zip") || n.ends_with(".tgz")
+                })
+                .count();
+            if count > 0 {
+                fields.push(MetadataField {
+                    label: "Packages".to_string(),
+                    value: count.to_string(),
+                });
+            }
+        }
+    }
+
+    fields
+}
+```
+
+- [ ] **Step 5: Add metadata tests**
+
+Add to the test module:
+
+```rust
+// --- metadata ---
+
+#[test]
+fn metadata_berry_zip_shows_format() {
+    let path = PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-abc123.zip");
+    let fields = metadata(&path);
+    assert_eq!(fields.len(), 1);
+    assert!(fields[0].value.contains("Berry"));
+}
+
+#[test]
+fn metadata_classic_tgz_shows_format() {
+    let path = PathBuf::from("/home/.yarn-cache/v6/npm-lodash-4.17.21-abc123.tgz");
+    let fields = metadata(&path);
+    assert_eq!(fields.len(), 1);
+    assert!(fields[0].value.contains("Classic"));
+}
+
+#[test]
+fn metadata_cache_dir_counts_packages() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cache = tmp.path().join("cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    std::fs::write(cache.join("lodash-npm-4.17.21-abc.zip"), "z").unwrap();
+    std::fs::write(cache.join("express-npm-4.21.0-def.zip"), "z").unwrap();
+    std::fs::write(cache.join(".gitignore"), "ignored").unwrap();
+
+    let fields = metadata(&cache);
+    let pkg_field = fields.iter().find(|f| f.label == "Packages").unwrap();
+    assert_eq!(pkg_field.value, "2");
+}
+```
+
+- [ ] **Step 6: Run all yarn tests**
+
+Run: `cargo test --lib providers::yarn::tests 2>&1 | tail -10`
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/providers/yarn.rs
+git commit -m "feat: add Yarn package_id and metadata"
+```
+
+---
+
+### Task 4: Wire Yarn into Dispatch
+
+**Files:**
+- Modify: `src/providers/mod.rs:51-177`
+
+- [ ] **Step 1: Write failing test for Yarn detection**
+
+Add to `src/providers/mod.rs` test module (after line 285):
+
+```rust
+#[test]
+fn detect_yarn_classic_cache() {
+    assert_eq!(
+        detect(&PathBuf::from("/home/user/.yarn-cache/v6/npm-lodash-4.17.21-abc.tgz")),
+        CacheKind::Yarn
+    );
+}
+
+#[test]
+fn detect_yarn_xdg_cache() {
+    assert_eq!(
+        detect(&PathBuf::from("/home/user/.cache/yarn/v6/npm-express-4.21.0-def.tgz")),
+        CacheKind::Yarn
+    );
+}
+
+#[test]
+fn detect_yarn_berry_cache() {
+    assert_eq!(
+        detect(&PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-abc.zip")),
+        CacheKind::Yarn
+    );
+}
+
+#[test]
+fn detect_yarn_macos_library() {
+    assert_eq!(
+        detect(&PathBuf::from("/Users/me/Library/Caches/Yarn/v6")),
+        CacheKind::Yarn
+    );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib providers::tests::detect_yarn_classic_cache 2>&1 | tail -5`
+Expected: FAIL — returns `CacheKind::Unknown`
+
+- [ ] **Step 3: Add Yarn detection to detect()**
+
+In `src/providers/mod.rs`, in the `detect` function, add Yarn detection. In the direct name match block (after line 69, before `_ => {}`):
+
+```rust
+".yarn-cache" => return CacheKind::Yarn,
+```
+
+In the ancestor walk (after line 90, before the `"registry"` match arm):
+
+```rust
+".yarn-cache" | "Yarn" => return CacheKind::Yarn,
+".yarn" => {
+    // .yarn/cache is Berry
+    if path.to_string_lossy().contains(".yarn/cache")
+        || path.to_string_lossy().contains(".yarn\\cache")
+    {
+        return CacheKind::Yarn;
+    }
+}
+"yarn" => {
+    // ~/.cache/yarn/ is Classic
+    if ancestor.to_string_lossy().contains(".cache") {
+        return CacheKind::Yarn;
+    }
+    // yarn/berry/cache is Berry global
+    if path.to_string_lossy().contains("berry/cache") {
+        return CacheKind::Yarn;
+    }
+}
+```
+
+- [ ] **Step 4: Update dispatch functions for Yarn**
+
+In `semantic_name()`, replace the temporary `CacheKind::Yarn => None` with:
+
+```rust
+CacheKind::Yarn => yarn::semantic_name(path),
+```
+
+In `metadata()`, replace `CacheKind::Yarn => generic::metadata(path)` with:
+
+```rust
+CacheKind::Yarn => yarn::metadata(path),
+```
+
+In `package_id()`, add before the `_ => None` arm:
+
+```rust
+CacheKind::Yarn => yarn::package_id(path),
+```
+
+In `upgrade_command()`, add before the `_ => None` arm:
+
+```rust
+CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
+```
+
+- [ ] **Step 5: Add upgrade_command test for Yarn**
+
+Add to the test module:
+
+```rust
+#[test]
+fn upgrade_command_yarn() {
+    assert_eq!(
+        upgrade_command(CacheKind::Yarn, "lodash", "4.17.21"),
+        Some("yarn add lodash@4.17.21".to_string())
+    );
+}
+```
+
+Remove `CacheKind::Yarn` from the `upgrade_command_unsupported_kinds_return_none` test array (it's now supported).
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cargo test 2>&1 | tail -10`
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/providers/mod.rs
+git commit -m "feat: wire Yarn provider into dispatch"
+```
+
+---
+
+### Task 5: pnpm Provider — Detection, Semantic Names & Package ID
+
+**Files:**
+- Create: `src/providers/pnpm.rs`
+- Modify: `src/providers/mod.rs:1-13` (module declaration)
+
+- [ ] **Step 1: Create pnpm.rs with full implementation and tests**
+
+Create `src/providers/pnpm.rs`:
+
+```rust
+use super::MetadataField;
+use std::path::Path;
+
+/// Identify whether a path is inside a pnpm cache.
+pub fn is_pnpm_cache(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains(".pnpm-store")
+        || path_str.contains("pnpm/store")
+        || is_pnpm_virtual_store(path)
+}
+
+/// Check if path is inside a pnpm virtual store (project-level).
+fn is_pnpm_virtual_store(path: &Path) -> bool {
+    path.to_string_lossy().contains("node_modules/.pnpm")
+}
+
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    match name.as_str() {
+        ".pnpm-store" => return Some("pnpm Content Store".to_string()),
+        ".pnpm" => return Some("pnpm Virtual Store".to_string()),
+        _ => {}
+    }
+
+    // Store version directories
+    if name.starts_with('v') && name[1..].chars().all(|c| c.is_ascii_digit()) {
+        let path_str = path.to_string_lossy();
+        if path_str.contains(".pnpm-store") || path_str.contains("pnpm/store") {
+            return Some(format!("Store {name}"));
+        }
+    }
+
+    if name == "files" {
+        let path_str = path.to_string_lossy();
+        if path_str.contains(".pnpm-store") || path_str.contains("pnpm/store") {
+            return Some("Content Files".to_string());
+        }
+    }
+
+    // Virtual store entries: name@version in node_modules/.pnpm/
+    if is_pnpm_virtual_store(path) && name.contains('@') {
+        if let Some((pkg_name, version)) = parse_virtual_store_name(&name) {
+            return Some(format!("{pkg_name} {version}"));
+        }
+    }
+
+    None
+}
+
+/// Parse a pnpm virtual store directory name.
+/// Format: `<name>@<version>` or `@scope+name@<version>`
+fn parse_virtual_store_name(dir_name: &str) -> Option<(String, String)> {
+    // Scoped: @scope+name@version
+    if dir_name.starts_with('@') {
+        // Find the second @ which separates name from version
+        let second_at = dir_name[1..].find('@')? + 1;
+        let raw_name = &dir_name[..second_at];
+        let version = &dir_name[second_at + 1..];
+        // Convert @scope+name to @scope/name
+        let pkg_name = raw_name.replace('+', "/");
+        if version.is_empty() {
+            return None;
+        }
+        return Some((pkg_name, version.to_string()));
+    }
+
+    // Unscoped: name@version
+    let at_pos = dir_name.rfind('@')?;
+    if at_pos == 0 {
+        return None;
+    }
+    let name = &dir_name[..at_pos];
+    let version = &dir_name[at_pos + 1..];
+    if version.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), version.to_string()))
+}
+
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Only extract package_id from virtual store entries (node_modules/.pnpm/<name>@<version>)
+    // Content-addressed store has no package identity in path
+    if !is_pnpm_virtual_store(path) || !name.contains('@') {
+        return None;
+    }
+
+    let (pkg_name, version) = parse_virtual_store_name(&name)?;
+
+    // Reject entries that don't look like real packages (e.g., "node_modules" dir)
+    if version
+        .chars()
+        .next()
+        .map(|c| !c.is_ascii_digit())
+        .unwrap_or(true)
+    {
+        return None;
+    }
+
+    Some(super::PackageId {
+        ecosystem: "npm",
+        name: pkg_name,
+        version,
+    })
+}
+
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if name == ".pnpm-store" || name == ".pnpm" {
+        if let Ok(entries) = std::fs::read_dir(path) {
+            let count = entries.filter_map(|e| e.ok()).count();
+            fields.push(MetadataField {
+                label: "Entries".to_string(),
+                value: count.to_string(),
+            });
+        }
+    }
+
+    let path_str = path.to_string_lossy();
+    if path_str.contains(".pnpm-store") {
+        fields.push(MetadataField {
+            label: "Type".to_string(),
+            value: "Content-addressed store".to_string(),
+        });
+    } else if is_pnpm_virtual_store(path) && name.contains('@') {
+        fields.push(MetadataField {
+            label: "Type".to_string(),
+            value: "Virtual store entry".to_string(),
+        });
+    }
+
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- is_pnpm_cache ---
+
+    #[test]
+    fn detects_pnpm_store() {
+        assert!(is_pnpm_cache(&PathBuf::from("/home/user/.pnpm-store/v3")));
+    }
+
+    #[test]
+    fn detects_pnpm_virtual_store() {
+        assert!(is_pnpm_cache(&PathBuf::from(
+            "/project/node_modules/.pnpm/lodash@4.17.21"
+        )));
+    }
+
+    #[test]
+    fn detects_xdg_pnpm_store() {
+        assert!(is_pnpm_cache(&PathBuf::from(
+            "/home/user/.local/share/pnpm/store/v3"
+        )));
+    }
+
+    #[test]
+    fn does_not_detect_unrelated_path() {
+        assert!(!is_pnpm_cache(&PathBuf::from(
+            "/home/user/.npm/_cacache"
+        )));
+    }
+
+    // --- parse_virtual_store_name ---
+
+    #[test]
+    fn parse_unscoped_package() {
+        let (name, ver) = parse_virtual_store_name("lodash@4.17.21").unwrap();
+        assert_eq!(name, "lodash");
+        assert_eq!(ver, "4.17.21");
+    }
+
+    #[test]
+    fn parse_scoped_package() {
+        let (name, ver) = parse_virtual_store_name("@babel+core@7.24.0").unwrap();
+        assert_eq!(name, "@babel/core");
+        assert_eq!(ver, "7.24.0");
+    }
+
+    #[test]
+    fn parse_scoped_types() {
+        let (name, ver) = parse_virtual_store_name("@types+node@22.0.0").unwrap();
+        assert_eq!(name, "@types/node");
+        assert_eq!(ver, "22.0.0");
+    }
+
+    #[test]
+    fn parse_empty_version_returns_none() {
+        assert!(parse_virtual_store_name("lodash@").is_none());
+    }
+
+    #[test]
+    fn parse_no_at_returns_none() {
+        assert!(parse_virtual_store_name("lodash").is_none());
+    }
+
+    // --- semantic_name ---
+
+    #[test]
+    fn semantic_name_pnpm_store() {
+        assert_eq!(
+            semantic_name(&PathBuf::from("/home/.pnpm-store")),
+            Some("pnpm Content Store".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_virtual_store() {
+        assert_eq!(
+            semantic_name(&PathBuf::from("/project/node_modules/.pnpm")),
+            Some("pnpm Virtual Store".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_store_version() {
+        assert_eq!(
+            semantic_name(&PathBuf::from("/home/.pnpm-store/v3")),
+            Some("Store v3".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_virtual_store_entry() {
+        assert_eq!(
+            semantic_name(&PathBuf::from(
+                "/project/node_modules/.pnpm/lodash@4.17.21"
+            )),
+            Some("lodash 4.17.21".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_virtual_store_scoped() {
+        assert_eq!(
+            semantic_name(&PathBuf::from(
+                "/project/node_modules/.pnpm/@babel+core@7.24.0"
+            )),
+            Some("@babel/core 7.24.0".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_content_files() {
+        assert_eq!(
+            semantic_name(&PathBuf::from("/home/.pnpm-store/v3/files")),
+            Some("Content Files".into())
+        );
+    }
+
+    // --- package_id ---
+
+    #[test]
+    fn package_id_virtual_store_entry() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "lodash");
+        assert_eq!(id.version, "4.17.21");
+    }
+
+    #[test]
+    fn package_id_virtual_store_scoped() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/@types+node@22.0.0");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "@types/node");
+        assert_eq!(id.version, "22.0.0");
+    }
+
+    #[test]
+    fn package_id_content_store_returns_none() {
+        let path = PathBuf::from("/home/.pnpm-store/v3/files/ab/cd1234");
+        assert!(package_id(&path).is_none());
+    }
+
+    #[test]
+    fn package_id_pnpm_dir_returns_none() {
+        let path = PathBuf::from("/project/node_modules/.pnpm");
+        assert!(package_id(&path).is_none());
+    }
+
+    // --- metadata ---
+
+    #[test]
+    fn metadata_pnpm_store_shows_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = tmp.path().join(".pnpm-store");
+        std::fs::create_dir_all(store.join("v3")).unwrap();
+
+        let fields = metadata(&store);
+        let entries_field = fields.iter().find(|f| f.label == "Entries");
+        assert!(entries_field.is_some());
+    }
+
+    #[test]
+    fn metadata_virtual_store_entry_shows_type() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21");
+        let fields = metadata(&path);
+        let type_field = fields.iter().find(|f| f.label == "Type").unwrap();
+        assert!(type_field.value.contains("Virtual"));
+    }
+
+    #[test]
+    fn metadata_content_store_shows_type() {
+        let path = PathBuf::from("/home/.pnpm-store/v3/files/ab");
+        let fields = metadata(&path);
+        let type_field = fields.iter().find(|f| f.label == "Type").unwrap();
+        assert!(type_field.value.contains("Content-addressed"));
+    }
+}
+```
+
+- [ ] **Step 2: Add module declaration**
+
+In `src/providers/mod.rs`, add after the `pub mod yarn;` line:
+
+```rust
+pub mod pnpm;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test --lib providers::pnpm::tests 2>&1 | tail -10`
+Expected: All pnpm unit tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/providers/pnpm.rs src/providers/mod.rs
+git commit -m "feat: add pnpm provider with detection, naming, and package_id"
+```
+
+---
+
+### Task 6: Wire pnpm into Dispatch
+
+**Files:**
+- Modify: `src/providers/mod.rs`
+
+- [ ] **Step 1: Write failing detection tests**
+
+Add to `src/providers/mod.rs` test module:
+
+```rust
+#[test]
+fn detect_pnpm_store() {
+    assert_eq!(
+        detect(&PathBuf::from("/home/user/.pnpm-store/v3/files/ab/cd")),
+        CacheKind::Pnpm
+    );
+}
+
+#[test]
+fn detect_pnpm_virtual_store() {
+    assert_eq!(
+        detect(&PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21")),
+        CacheKind::Pnpm
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test --lib providers::tests::detect_pnpm_store 2>&1 | tail -5`
+Expected: FAIL — returns `CacheKind::Unknown`
+
+- [ ] **Step 3: Add pnpm detection to detect()**
+
+In `src/providers/mod.rs`, in the direct name match block (before `_ => {}`):
+
+```rust
+".pnpm-store" => return CacheKind::Pnpm,
+".pnpm" => return CacheKind::Pnpm,
+```
+
+In the ancestor walk (before the `"registry"` match arm):
+
+```rust
+".pnpm-store" => return CacheKind::Pnpm,
+".pnpm" => {
+    // node_modules/.pnpm is pnpm virtual store
+    if ancestor.to_string_lossy().contains("node_modules") {
+        return CacheKind::Pnpm;
+    }
+}
+```
+
+**Important ordering note:** The `.pnpm` ancestor match must come BEFORE any npm-related matching. Since `node_modules/.pnpm` also contains `node_modules`, we need to check for `.pnpm` first so it doesn't get detected as npm. Move the `.pnpm` and `.pnpm-store` matches to be checked before the npm-related matches in the ancestor walk.
+
+- [ ] **Step 4: Update dispatch functions for pnpm**
+
+In `semantic_name()`, replace `CacheKind::Pnpm => None` with:
+
+```rust
+CacheKind::Pnpm => pnpm::semantic_name(path),
+```
+
+In `metadata()`, replace `CacheKind::Pnpm => generic::metadata(path)` with:
+
+```rust
+CacheKind::Pnpm => pnpm::metadata(path),
+```
+
+In `package_id()`, add before the `_ => None` arm:
+
+```rust
+CacheKind::Pnpm => pnpm::package_id(path),
+```
+
+In `upgrade_command()`, add before the `_ => None` arm:
+
+```rust
+CacheKind::Pnpm => Some(format!("pnpm add {name}@{version}")),
+```
+
+- [ ] **Step 5: Update safety() for pnpm virtual store**
+
+The spec requires `SafetyLevel::Caution` for pnpm virtual store entries. Currently `safety()` returns `Safe` for all known kinds via a wildcard. Update:
+
+```rust
+pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
+    match kind {
+        CacheKind::Pnpm => {
+            if path.to_string_lossy().contains("node_modules/.pnpm") {
+                SafetyLevel::Caution
+            } else {
+                SafetyLevel::Safe
+            }
+        }
+        CacheKind::Unknown => SafetyLevel::Caution,
+        _ => SafetyLevel::Safe,
+    }
+}
+```
+
+Update the safety test for pnpm (replace the existing `assert_eq!(safety(CacheKind::Pnpm, &path), SafetyLevel::Safe)` line):
+
+```rust
+// pnpm store is safe
+assert_eq!(
+    safety(CacheKind::Pnpm, &PathBuf::from("/home/.pnpm-store/v3")),
+    SafetyLevel::Safe
+);
+```
+
+And add a new test:
+
+```rust
+#[test]
+fn safety_pnpm_virtual_store_is_caution() {
+    assert_eq!(
+        safety(
+            CacheKind::Pnpm,
+            &PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21")
+        ),
+        SafetyLevel::Caution
+    );
+}
+```
+
+- [ ] **Step 6: Add upgrade_command test**
+
+```rust
+#[test]
+fn upgrade_command_pnpm() {
+    assert_eq!(
+        upgrade_command(CacheKind::Pnpm, "lodash", "4.17.21"),
+        Some("pnpm add lodash@4.17.21".to_string())
+    );
+}
+```
+
+Remove `CacheKind::Pnpm` from the `upgrade_command_unsupported_kinds_return_none` array.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cargo test 2>&1 | tail -10`
+Expected: All pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/providers/mod.rs
+git commit -m "feat: wire pnpm provider into dispatch with path-aware safety"
+```
+
+---
+
+### Task 7: Auto-Detection of Cache Paths
+
+**Files:**
+- Modify: `src/config.rs:105-131`
+
+- [ ] **Step 1: Write failing test for fallback paths**
+
+Add to the test module in `src/config.rs`:
+
+```rust
+#[test]
+fn config_default_includes_yarn_classic_cache_if_exists() {
+    // This test verifies the logic, not that the dir exists on this machine
+    let config = Config::default();
+    // Just verify our code doesn't panic — actual path existence varies
+    let _ = config.roots;
+}
+
+#[test]
+fn probe_yarn_cache_returns_none_when_not_installed() {
+    // yarn is not on this system, so probe should return empty vec
+    let paths = probe_yarn_paths();
+    // May or may not find paths depending on system — just verify no panic
+    let _ = paths;
+}
+
+#[test]
+fn probe_pnpm_cache_returns_none_when_not_installed() {
+    let paths = probe_pnpm_paths();
+    let _ = paths;
+}
+```
+
+- [ ] **Step 2: Implement CLI probing functions**
+
+Add to `src/config.rs` (before the `impl Default for Config` block):
+
+```rust
+/// Probe for Yarn cache paths by running CLI commands and checking fallback locations.
+fn probe_yarn_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Try CLI detection (with 2s timeout)
+    if let Ok(output) = std::process::Command::new("yarn")
+        .args(["cache", "dir"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+
+    // Fallback locations
+    let home = dirs_home();
+    let fallbacks = [
+        home.join(".yarn-cache"),
+        home.join(".cache/yarn"),
+        home.join(".yarn/berry/cache"),
+    ];
+    #[cfg(target_os = "macos")]
+    let macos_fallbacks = [home.join("Library/Caches/Yarn")];
+    #[cfg(not(target_os = "macos"))]
+    let macos_fallbacks: [PathBuf; 0] = [];
+
+    for path in fallbacks.iter().chain(macos_fallbacks.iter()) {
+        if path.exists() && !paths.contains(path) {
+            paths.push(path.clone());
+        }
+    }
+
+    paths
+}
+
+/// Probe for pnpm store paths by running CLI commands and checking fallback locations.
+fn probe_pnpm_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Try CLI detection
+    if let Ok(output) = std::process::Command::new("pnpm")
+        .args(["store", "path"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+
+    // Fallback locations
+    let home = dirs_home();
+    let fallbacks = [
+        home.join(".pnpm-store"),
+        home.join(".local/share/pnpm/store"),
+    ];
+
+    for path in &fallbacks {
+        if path.exists() && !paths.contains(path) {
+            paths.push(path.clone());
+        }
+    }
+
+    paths
+}
+```
+
+- [ ] **Step 3: Integrate probing into Config::default()**
+
+In the `Default` impl for `Config`, after the cargo registry check (line 120), add:
+
+```rust
+// Yarn cache paths
+for path in probe_yarn_paths() {
+    if !roots.contains(&path) {
+        roots.push(path);
+    }
+}
+
+// pnpm store paths
+for path in probe_pnpm_paths() {
+    if !roots.contains(&path) {
+        roots.push(path);
+    }
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cargo test 2>&1 | tail -10`
+Expected: All pass. The probe functions gracefully handle missing tools.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs
+git commit -m "feat: auto-detect Yarn and pnpm cache paths at startup"
+```
+
+---
+
+### Task 8: Integration Tests with Fixtures
+
+**Files:**
+- Modify: `tests/integration.rs`
+
+- [ ] **Step 1: Add Yarn cache fixture helper**
+
+Add to `tests/integration.rs` (after the `create_npx_cache` function):
+
+```rust
+/// Create a fake Yarn Berry cache structure.
+fn create_yarn_berry_cache(root: &std::path::Path) {
+    let yarn_cache = root.join(".yarn/cache");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(
+        yarn_cache.join("lodash-npm-4.17.21-6382d821f21d.zip"),
+        "fake zip contents",
+    )
+    .unwrap();
+    std::fs::write(
+        yarn_cache.join("@babel-core-npm-7.24.0-abc123def456.zip"),
+        "fake zip contents",
+    )
+    .unwrap();
+}
+
+/// Create a fake Yarn Classic cache structure.
+fn create_yarn_classic_cache(root: &std::path::Path) {
+    let yarn_cache = root.join(".yarn-cache/v6");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(
+        yarn_cache.join("npm-express-4.21.0-abcdef123456.tgz"),
+        "fake tgz contents",
+    )
+    .unwrap();
+}
+
+/// Create a fake pnpm virtual store structure.
+fn create_pnpm_cache(root: &std::path::Path) {
+    // Virtual store
+    let pnpm_vs = root.join("node_modules/.pnpm");
+    let lodash = pnpm_vs.join("lodash@4.17.21/node_modules/lodash");
+    std::fs::create_dir_all(&lodash).unwrap();
+    std::fs::write(lodash.join("index.js"), "module.exports = {}").unwrap();
+
+    let babel = pnpm_vs.join("@babel+core@7.24.0/node_modules/@babel/core");
+    std::fs::create_dir_all(&babel).unwrap();
+    std::fs::write(babel.join("index.js"), "module.exports = {}").unwrap();
+
+    // Content store
+    let store = root.join(".pnpm-store/v3/files/ab");
+    std::fs::create_dir_all(&store).unwrap();
+    std::fs::write(store.join("cd1234abcdef"), "blob content").unwrap();
+}
+```
+
+- [ ] **Step 2: Add Yarn discovery test**
+
+```rust
+#[test]
+fn yarn_discover_packages_finds_berry_zips() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_berry_cache(tmp.path());
+
+    let packages =
+        ccmd::scanner::discover_packages(&[tmp.path().join(".yarn")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"lodash"),
+        "Should find lodash: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {:?}",
+        names
+    );
+    assert_eq!(
+        packages
+            .iter()
+            .filter(|(_, id)| id.ecosystem == "npm")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn yarn_discover_packages_finds_classic_tgz() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_classic_cache(tmp.path());
+
+    let packages =
+        ccmd::scanner::discover_packages(&[tmp.path().join(".yarn-cache")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"express"),
+        "Should find express: {:?}",
+        names
+    );
+}
+```
+
+- [ ] **Step 3: Add pnpm discovery test**
+
+```rust
+#[test]
+fn pnpm_discover_packages_finds_virtual_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_pnpm_cache(tmp.path());
+
+    let packages =
+        ccmd::scanner::discover_packages(&[tmp.path().join("node_modules/.pnpm")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"lodash"),
+        "Should find lodash: {:?}",
+        names
+    );
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {:?}",
+        names
+    );
+}
+
+#[test]
+fn pnpm_content_store_returns_no_packages() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_pnpm_cache(tmp.path());
+
+    let packages =
+        ccmd::scanner::discover_packages(&[tmp.path().join(".pnpm-store")]);
+
+    // Content-addressed store has no identifiable packages
+    assert_eq!(packages.len(), 0, "Store blobs should not yield packages");
+}
+```
+
+- [ ] **Step 4: Add scanner expand test for Yarn**
+
+```rust
+#[test]
+fn scanner_expand_yarn_berry_shows_semantic_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_berry_cache(tmp.path());
+
+    let cache_path = tmp.path().join(".yarn/cache");
+
+    let (result_tx, result_rx) = mpsc::channel();
+    let scan_tx = ccmd::scanner::start(result_tx);
+
+    scan_tx
+        .send(ccmd::scanner::ScanRequest::ExpandNode(cache_path))
+        .unwrap();
+
+    let result = result_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    match result {
+        ccmd::scanner::ScanResult::ChildrenScanned(_, children) => {
+            let names: Vec<&str> = children.iter().map(|n| n.name.as_str()).collect();
+            assert!(
+                names.iter().any(|n| n.contains("lodash") && n.contains("4.17.21")),
+                "Should show 'lodash 4.17.21': {:?}",
+                names
+            );
+            assert!(
+                names.iter().any(|n| n.contains("@babel/core")),
+                "Should show '@babel/core 7.24.0': {:?}",
+                names
+            );
+
+            // Verify kind detection
+            for child in &children {
+                assert_eq!(
+                    child.kind,
+                    ccmd::tree::node::CacheKind::Yarn,
+                    "All children should be detected as Yarn: {:?}",
+                    child.name
+                );
+            }
+        }
+        _ => panic!("Expected ChildrenScanned"),
+    }
+}
+```
+
+- [ ] **Step 5: Add deduplication test across providers**
+
+```rust
+#[test]
+fn dedup_across_npm_and_yarn_caches() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Same package in both npm and yarn caches
+    // npm: express via node_modules
+    let npm_dir = tmp.path().join(".npm/_npx/abc/node_modules/express");
+    std::fs::create_dir_all(&npm_dir).unwrap();
+    std::fs::write(
+        npm_dir.join("package.json"),
+        r#"{"name":"express","version":"4.21.0"}"#,
+    )
+    .unwrap();
+
+    // yarn: express via berry zip
+    let yarn_cache = tmp.path().join(".yarn/cache");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(
+        yarn_cache.join("express-npm-4.21.0-abcdef123456.zip"),
+        "z",
+    )
+    .unwrap();
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().to_path_buf()]);
+
+    // Should find express only once (dedup by ecosystem+name+version)
+    let express_count = packages
+        .iter()
+        .filter(|(_, id)| id.name == "express" && id.version == "4.21.0")
+        .count();
+    assert_eq!(
+        express_count, 1,
+        "express@4.21.0 should be deduplicated across npm and yarn"
+    );
+}
+```
+
+- [ ] **Step 6: Run all integration tests**
+
+Run: `cargo test --test integration 2>&1 | tail -15`
+Expected: All pass, including the new Yarn/pnpm tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/integration.rs
+git commit -m "test: add Yarn and pnpm integration tests with fixtures"
+```
+
+---
+
+### Task 9: E2E Test Setup & Feature Flag
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `tests/e2e_js_providers.rs`
+
+- [ ] **Step 1: Add e2e feature flag to Cargo.toml**
+
+In `Cargo.toml`, in the `[features]` section (after line 31):
+
+```toml
+e2e = []
+```
+
+- [ ] **Step 2: Create E2E test file**
+
+Create `tests/e2e_js_providers.rs`:
+
+```rust
+//! End-to-end tests for Yarn and pnpm providers using real tools.
+//! Requires Yarn and pnpm to be installed.
+//! Run with: cargo test --features e2e --test e2e_js_providers
+#![cfg(feature = "e2e")]
+
+use std::process::Command;
+
+/// Check if a command is available on PATH.
+fn is_available(cmd: &str) -> bool {
+    Command::new("which").arg(cmd).output().map(|o| o.status.success()).unwrap_or(false)
+}
+
+/// Run a command in a directory and assert success.
+fn run_in(dir: &std::path::Path, cmd: &str, args: &[&str]) {
+    let output = Command::new(cmd)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run {} {:?}: {}", cmd, args, e));
+    assert!(
+        output.status.success(),
+        "{} {:?} failed:\nstdout: {}\nstderr: {}",
+        cmd,
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// --- Yarn Classic E2E ---
+
+#[test]
+fn e2e_yarn_classic_cache_detection() {
+    if !is_available("yarn") {
+        eprintln!("SKIP: yarn not installed");
+        return;
+    }
+
+    // Check if this is Yarn Classic (1.x)
+    let output = Command::new("yarn").arg("--version").output().unwrap();
+    let version = String::from_utf8_lossy(&output.stdout);
+    if !version.starts_with('1') {
+        eprintln!("SKIP: yarn is not Classic (1.x), got {}", version.trim());
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("classic-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize project and install a package
+    run_in(&project, "npm", &["init", "-y"]);
+    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
+
+    // Find yarn cache dir
+    let output = Command::new("yarn")
+        .args(["cache", "dir"])
+        .output()
+        .unwrap();
+    let cache_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let cache_path = std::path::PathBuf::from(&cache_dir);
+
+    assert!(cache_path.exists(), "Yarn cache dir should exist: {}", cache_dir);
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[cache_path]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in Yarn Classic cache: {:?}",
+        names
+    );
+
+    // Clean up: remove the cached package
+    let _ = Command::new("yarn").args(["cache", "clean", "is-even"]).output();
+}
+
+// --- Yarn Berry E2E ---
+
+#[test]
+fn e2e_yarn_berry_cache_detection() {
+    if !is_available("corepack") {
+        eprintln!("SKIP: corepack not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("berry-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize Berry project
+    run_in(&project, "npm", &["init", "-y"]);
+    run_in(&project, "corepack", &["enable"]);
+    run_in(&project, "yarn", &["set", "version", "berry"]);
+    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
+
+    // Berry cache is per-project at .yarn/cache/
+    let cache_path = project.join(".yarn/cache");
+    assert!(cache_path.exists(), ".yarn/cache should exist");
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[project.join(".yarn")]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in Berry cache: {:?}",
+        names
+    );
+}
+
+// --- pnpm E2E ---
+
+#[test]
+fn e2e_pnpm_virtual_store_detection() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("pnpm-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize and install
+    run_in(&project, "pnpm", &["init"]);
+    run_in(&project, "pnpm", &["add", "is-even@1.0.0"]);
+
+    // pnpm creates node_modules/.pnpm/
+    let pnpm_dir = project.join("node_modules/.pnpm");
+    assert!(pnpm_dir.exists(), "node_modules/.pnpm should exist");
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[project.join("node_modules/.pnpm")]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in pnpm virtual store: {:?}",
+        names
+    );
+}
+
+#[test]
+fn e2e_pnpm_store_path_detection() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let output = Command::new("pnpm").args(["store", "path"]).output().unwrap();
+    if output.status.success() {
+        let store_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = std::path::PathBuf::from(&store_path);
+        assert!(path.exists(), "pnpm store path should exist: {}", store_path);
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo test --features e2e --test e2e_js_providers --no-run 2>&1 | tail -5`
+Expected: Compiles successfully (tests don't need to run yet — tools may not be installed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml tests/e2e_js_providers.rs
+git commit -m "test: add E2E test suite for Yarn and pnpm with real tools"
+```
+
+---
+
+### Task 10: CI Workflow for E2E Tests
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Read current CI config**
+
+Read `.github/workflows/ci.yml` to understand the existing job structure.
+
+- [ ] **Step 2: Add E2E test job**
+
+Add a new job to `.github/workflows/ci.yml` after the existing test jobs:
+
+```yaml
+  e2e-js-providers:
+    name: E2E JS Provider Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install Yarn Classic
+        run: npm install -g yarn@1
+
+      - name: Enable Corepack (for Yarn Berry)
+        run: corepack enable
+
+      - name: Run E2E tests
+        run: cargo test --features e2e --test e2e_js_providers -- --test-threads=1
+```
+
+Note: `--test-threads=1` prevents parallel test runs from conflicting on global Yarn cache state.
+
+- [ ] **Step 3: Run existing CI tests locally to verify no breakage**
+
+Run: `cargo test 2>&1 | tail -10`
+Expected: All existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add E2E test job for Yarn and pnpm providers"
+```
+
+---
+
+### Task 11: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cargo test 2>&1`
+Expected: All unit tests, integration tests pass.
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy -- -D warnings 2>&1 | tail -10`
+Expected: No warnings.
+
+- [ ] **Step 3: Run cargo fmt check**
+
+Run: `cargo fmt --check 2>&1`
+Expected: No formatting issues.
+
+- [ ] **Step 4: Verify E2E tests compile**
+
+Run: `cargo test --features e2e --test e2e_js_providers --no-run 2>&1 | tail -5`
+Expected: Compiles.
+
+- [ ] **Step 5: Commit any remaining fixes (if needed)**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for Yarn and pnpm providers"
+```

--- a/docs/superpowers/specs/2026-04-08-yarn-pnpm-providers-design.md
+++ b/docs/superpowers/specs/2026-04-08-yarn-pnpm-providers-design.md
@@ -1,0 +1,232 @@
+# Yarn & pnpm Provider Support
+
+**Date:** 2026-04-08
+**Issue:** [juliensimon/cache-commander#1](https://github.com/juliensimon/cache-commander/issues/1)
+**Status:** Design
+
+## Summary
+
+Add Yarn (Classic + Berry) and pnpm cache providers to cache-explorer, enabling detection, display, vulnerability scanning, version checking, and cleanup for all three major JS package managers.
+
+## Approach
+
+Approach A: One `CacheKind::Yarn` (handles both Yarn 1 and 2+ internally) and one `CacheKind::Pnpm`. Auto-detection of cache paths via CLI probing, with config overrides.
+
+## Provider: Yarn (`src/providers/yarn.rs`)
+
+### Detection
+
+`detect(path)` returns `CacheKind::Yarn` when path components match:
+- `.yarn-cache/` or `.cache/yarn/` (Yarn 1 Classic global cache)
+- `.yarn/cache/` (Yarn 2+ Berry per-project cache)
+- `Library/Caches/Yarn/` (macOS Yarn 1)
+- `berry/cache/` inside Yarn global folder
+
+### Package Identification
+
+Two formats, branched internally:
+
+**Yarn 1 (Classic):** Tarballs named `npm-<name>-<version>-<hash>.tgz`
+- Parse filename: strip `npm-` prefix, extract name and version
+- Scoped packages: `npm-@scope-name-<version>-<hash>.tgz`
+- `PackageId { ecosystem: "npm", name, version }`
+
+**Yarn 2+ (Berry):** Zip archives named `<name>-npm-<version>-<hash>.zip`
+- Parse filename: split on `-npm-`, extract name and version before hash
+- Scoped packages: `@scope-name-npm-<version>-<hash>.zip`
+- `PackageId { ecosystem: "npm", name, version }`
+
+### Semantic Names
+
+- Yarn 1 tarball: `"lodash 4.17.21"` (parsed from filename)
+- Berry zip: `"lodash 4.17.21"` (parsed from filename)
+- Known directories: `"Yarn Cache"`, `"Yarn Logs"`, etc.
+
+### Metadata
+
+- Package format (tgz vs zip)
+- Yarn version detected (Classic vs Berry)
+- File size
+- Install script detection (if extractable)
+
+### Safety
+
+All Yarn cache entries: `SafetyLevel::Safe` (re-downloadable from npm registry).
+
+### Upgrade Command
+
+`yarn add <name>@<version>`
+
+## Provider: pnpm (`src/providers/pnpm.rs`)
+
+### Detection
+
+`detect(path)` returns `CacheKind::Pnpm` when path components match:
+- `.pnpm-store/` (global content-addressed store)
+- `node_modules/.pnpm/` (project-level virtual store)
+- `pnpm/store/` inside XDG cache directories
+
+### Package Identification
+
+**`node_modules/.pnpm/` (reliable path):** Directories named `<name>@<version>/node_modules/<name>`
+- Parse folder name: split on `@` to extract name and version
+- Scoped packages: `@scope+name@<version>` (pnpm uses `+` as path separator for scopes)
+- `PackageId { ecosystem: "npm", name, version }`
+
+**`.pnpm-store/` (content-addressed):** Hash-based blobs with no package identity in path.
+- `package_id()` returns `None` for store-level entries
+- Still detected as `CacheKind::Pnpm` for display and cleanup
+
+### Semantic Names
+
+- `node_modules/.pnpm/lodash@4.17.21/...` -> `"lodash 4.17.21"`
+- `.pnpm-store/v3/` -> `"pnpm Content Store"`
+- `.pnpm-store/v3/files/` -> `"Content Files"`
+
+### Metadata
+
+- Package name and version (from `node_modules/.pnpm/` path)
+- Store version (v3, etc.)
+- File count and size
+- Whether entry is content-addressed or virtual store
+
+### Safety
+
+- `.pnpm-store/` entries: `SafetyLevel::Safe` (re-downloadable, pnpm re-fetches on next install)
+- `node_modules/.pnpm/` entries: `SafetyLevel::Caution` (deletion triggers re-install in that project)
+
+### Upgrade Command
+
+`pnpm add <name>@<version>`
+
+## Auto-Detection of Cache Paths (`src/config.rs`)
+
+### CLI Probing (at startup)
+
+If tool is on PATH:
+- `yarn cache dir` -> Yarn 1 global cache path
+- `yarn config get cacheFolder` -> Yarn 2+ cache path
+- `pnpm store path` -> pnpm global store path
+
+Add discovered paths to scan roots. Timeout: 2 seconds per command. Failures are silent (tool may not be installed).
+
+### Fallback Locations (checked even if tool not installed)
+
+Orphaned caches are valuable cleanup targets:
+
+| Path | OS | Tool |
+|------|----|------|
+| `~/.cache/yarn/` | Linux | Yarn 1 |
+| `~/.yarn-cache/` | Linux/macOS | Yarn 1 |
+| `~/Library/Caches/Yarn/` | macOS | Yarn 1 |
+| `~/.yarn/berry/cache/` | All | Yarn 2+ |
+| `~/.pnpm-store/` | All | pnpm |
+| `~/.local/share/pnpm/store/` | Linux | pnpm |
+
+### Config Override
+
+Users can add/remove roots in `~/.config/ccmd/config.toml`. Config entries take precedence over auto-detection.
+
+## Dispatch Integration (`src/providers/mod.rs`)
+
+Add `mod yarn;` and `mod pnpm;` declarations. Add `CacheKind::Yarn` and `CacheKind::Pnpm` arms to:
+
+- `detect()` — path-based detection as described above
+- `semantic_name()` — dispatch to `yarn::semantic_name` / `pnpm::semantic_name`
+- `metadata()` — dispatch to `yarn::metadata` / `pnpm::metadata`
+- `package_id()` — dispatch to `yarn::package_id` / `pnpm::package_id`
+- `upgrade_command()` — `yarn add` / `pnpm add`
+
+## CacheKind Enum (`src/tree/node.rs`)
+
+Add two variants:
+
+| Variant | `label()` | `description()` | `url()` |
+|---------|-----------|------------------|---------|
+| `Yarn` | `"Yarn"` | `"Yarn package manager cache"` | `"https://yarnpkg.com"` |
+| `Pnpm` | `"pnpm"` | `"pnpm package manager cache"` | `"https://pnpm.io"` |
+
+## UI Impact
+
+None. The existing tree view, detail panel, and deletion flow work generically off `CacheKind`, `MetadataField`, and `SafetyLevel`. New providers slot in automatically.
+
+## Testing Strategy
+
+### Tier 1: Unit Tests (in-module, `#[cfg(test)]`)
+
+Located in `yarn.rs` and `pnpm.rs`. Use `tempfile::tempdir()` to create synthetic cache structures.
+
+**Yarn tests:**
+- Detect Yarn 1 cache from `.yarn-cache/` path
+- Detect Yarn 2+ cache from `.yarn/cache/` path
+- Parse Yarn 1 tarball filename: `npm-lodash-4.17.21-<hash>.tgz` -> name=lodash, version=4.17.21
+- Parse Berry zip filename: `lodash-npm-4.17.21-<hash>.zip` -> name=lodash, version=4.17.21
+- Parse scoped packages: `npm-@babel-core-7.24.0-<hash>.tgz`, `@babel-core-npm-7.24.0-<hash>.zip`
+- Semantic name formatting
+- Metadata field generation
+- Edge cases: malformed filenames return None, pre-release versions, very long package names
+
+**pnpm tests:**
+- Detect pnpm store from `.pnpm-store/` path
+- Detect virtual store from `node_modules/.pnpm/` path
+- Parse `lodash@4.17.21` folder name -> name=lodash, version=4.17.21
+- Parse scoped: `@babel+core@7.24.0` -> name=@babel/core, version=7.24.0
+- `package_id()` returns None for content-addressed store entries
+- Safety levels: Safe for store, Caution for virtual store
+
+### Tier 2: Integration Tests (`tests/integration.rs`)
+
+Extend existing integration test file:
+- Create tempdir with Yarn + pnpm cache fixtures alongside existing npm/pip/cargo fixtures
+- Run `discover_packages()` and verify Yarn/pnpm packages found
+- Run scanner pipeline (via channels) and verify tree expansion shows correct semantic names
+- Verify deduplication: same package in npm and Yarn cache counted once in vulnerability scan
+
+### Tier 3: End-to-End Tests (`tests/e2e_js_providers.rs`)
+
+Gated behind `#[cfg(feature = "e2e")]`. Require real Yarn + pnpm installed.
+
+**Setup per test:**
+1. Create temp project directory
+2. Install tool if not present (or skip test with clear message)
+3. `npm init -y` in temp dir
+4. Install real packages (e.g., `lodash@4.17.21`)
+
+**Yarn 1 E2E:**
+- Set up Yarn Classic environment, install packages
+- Run `yarn cache dir` to find cache
+- Point scanner at cache, verify `lodash` discovered with correct version
+
+**Yarn 2+ E2E:**
+- `corepack enable && yarn init -2` in temp dir
+- `yarn add lodash@4.17.21`
+- Verify `.yarn/cache/` contains zip, scanner finds it
+
+**pnpm E2E:**
+- `pnpm init && pnpm add lodash@4.17.21`
+- Verify `node_modules/.pnpm/lodash@4.17.21` exists
+- Scanner discovers package with correct PackageId
+- Run `pnpm store path`, verify auto-detection returns valid path
+
+**CI:** Separate workflow job that installs yarn + pnpm, runs `cargo test --features e2e`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tree/node.rs` | Add `Yarn`, `Pnpm` to `CacheKind` enum with label/description/url |
+| `src/providers/mod.rs` | Add `mod yarn; mod pnpm;`, add match arms to all dispatch functions |
+| `src/providers/yarn.rs` | **New** — Yarn 1 + 2+ provider |
+| `src/providers/pnpm.rs` | **New** — pnpm provider |
+| `src/config.rs` | Add auto-detection probing and fallback paths |
+| `Cargo.toml` | Add `e2e` feature flag |
+| `tests/integration.rs` | Add Yarn/pnpm fixture tests |
+| `tests/e2e_js_providers.rs` | **New** — E2E tests with real tools |
+| `.github/workflows/ci.yml` | Add E2E test job with yarn + pnpm installation |
+
+## Out of Scope
+
+- Bun package manager support (separate future enhancement)
+- pnpm package identification from content-addressed store hashes (only virtual store `node_modules/.pnpm/` paths)
+- Yarn PnP (Plug'n'Play) `.pnp.cjs` file parsing
+- Custom registry support (all packages assumed from npm registry)

--- a/docs/superpowers/specs/2026-04-08-yarn-pnpm-providers-design.md
+++ b/docs/superpowers/specs/2026-04-08-yarn-pnpm-providers-design.md
@@ -51,7 +51,8 @@ Two formats, branched internally:
 
 ### Safety
 
-All Yarn cache entries: `SafetyLevel::Safe` (re-downloadable from npm registry).
+- Yarn Classic global caches and Yarn global Berry caches: `SafetyLevel::Safe` (re-downloadable from npm registry).
+- Project-local Yarn Berry caches under `.yarn/cache/`: `SafetyLevel::Caution` (may be committed to git for zero-install).
 
 ### Upgrade Command
 
@@ -108,7 +109,7 @@ If tool is on PATH:
 - `yarn config get cacheFolder` -> Yarn 2+ cache path
 - `pnpm store path` -> pnpm global store path
 
-Add discovered paths to scan roots. Timeout: 2 seconds per command. Failures are silent (tool may not be installed).
+Add discovered paths to scan roots. Failures are silent (tool may not be installed or probing may fail).
 
 ### Fallback Locations (checked even if tool not installed)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,6 +204,22 @@ fn probe_yarn_paths() -> Vec<PathBuf> {
         }
     }
 
+    // Yarn 2+ (Berry) cache folder
+    if let Ok(output) = std::process::Command::new("yarn")
+        .args(["config", "get", "cacheFolder"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path_str.is_empty() && path_str != "undefined" {
+                let path = PathBuf::from(&path_str);
+                if path.exists() && !paths.contains(&path) {
+                    paths.push(path);
+                }
+            }
+        }
+    }
+
     // Fallback locations
     let home = dirs_home();
     let fallbacks = [

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,8 +173,18 @@ impl Config {
             .roots
             .into_iter()
             .map(|p| expand_tilde(&p))
-            .filter(|p| p.exists())
-            .collect();
+            .collect::<Vec<_>>();
+
+        // Warn about non-existent roots specified via CLI
+        if !cli.roots.is_empty() {
+            for root in &config.roots {
+                if !root.exists() {
+                    eprintln!("warning: root path does not exist: {}", root.display());
+                }
+            }
+        }
+
+        config.roots.retain(|p| p.exists());
 
         (config, cli)
     }
@@ -182,8 +192,21 @@ impl Config {
     fn load_from_file() -> Option<Self> {
         let proj = ProjectDirs::from("", "", "ccmd")?;
         let config_path = proj.config_dir().join("config.toml");
-        let content = std::fs::read_to_string(config_path).ok()?;
-        toml::from_str(&content).ok()
+        let content = match std::fs::read_to_string(&config_path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(e) => {
+                eprintln!("warning: could not read {}: {}", config_path.display(), e);
+                return None;
+            }
+        };
+        match toml::from_str(&content) {
+            Ok(config) => Some(config),
+            Err(e) => {
+                eprintln!("warning: invalid config {}: {}", config_path.display(), e);
+                None
+            }
+        }
     }
 }
 
@@ -193,6 +216,7 @@ fn probe_yarn_paths() -> Vec<PathBuf> {
     // Try CLI detection
     if let Ok(output) = std::process::Command::new("yarn")
         .args(["cache", "dir"])
+        .stdin(std::process::Stdio::null())
         .output()
     {
         if output.status.success() {
@@ -207,6 +231,7 @@ fn probe_yarn_paths() -> Vec<PathBuf> {
     // Yarn 2+ (Berry) cache folder
     if let Ok(output) = std::process::Command::new("yarn")
         .args(["config", "get", "cacheFolder"])
+        .stdin(std::process::Stdio::null())
         .output()
     {
         if output.status.success() {
@@ -247,6 +272,7 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
     // Try CLI detection
     if let Ok(output) = std::process::Command::new("pnpm")
         .args(["store", "path"])
+        .stdin(std::process::Stdio::null())
         .output()
     {
         if output.status.success() {
@@ -277,7 +303,10 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
 fn dirs_home() -> PathBuf {
     directories::BaseDirs::new()
         .map(|d| d.home_dir().to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/"))
+        .unwrap_or_else(|| {
+            eprintln!("warning: could not determine home directory, using /");
+            PathBuf::from("/")
+        })
 }
 
 fn expand_tilde(path: &Path) -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,20 @@ impl Default for Config {
             roots.push(cargo_registry);
         }
 
+        // Yarn cache paths
+        for path in probe_yarn_paths() {
+            if !roots.contains(&path) {
+                roots.push(path);
+            }
+        }
+
+        // pnpm store paths
+        for path in probe_pnpm_paths() {
+            if !roots.contains(&path) {
+                roots.push(path);
+            }
+        }
+
         Self {
             roots,
             sort_by: SortField::Size,
@@ -171,6 +185,77 @@ impl Config {
         let content = std::fs::read_to_string(config_path).ok()?;
         toml::from_str(&content).ok()
     }
+}
+
+fn probe_yarn_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Try CLI detection
+    if let Ok(output) = std::process::Command::new("yarn")
+        .args(["cache", "dir"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+
+    // Fallback locations
+    let home = dirs_home();
+    let fallbacks = [
+        home.join(".yarn-cache"),
+        home.join(".cache/yarn"),
+        home.join(".yarn/berry/cache"),
+    ];
+    #[cfg(target_os = "macos")]
+    let macos_fallbacks = [home.join("Library/Caches/Yarn")];
+    #[cfg(not(target_os = "macos"))]
+    let macos_fallbacks: [PathBuf; 0] = [];
+
+    for path in fallbacks.iter().chain(macos_fallbacks.iter()) {
+        if path.exists() && !paths.contains(path) {
+            paths.push(path.clone());
+        }
+    }
+
+    paths
+}
+
+fn probe_pnpm_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Try CLI detection
+    if let Ok(output) = std::process::Command::new("pnpm")
+        .args(["store", "path"])
+        .output()
+    {
+        if output.status.success() {
+            let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+
+    // Fallback locations
+    let home = dirs_home();
+    let fallbacks = [
+        home.join(".pnpm-store"),
+        home.join(".local/share/pnpm/store"),
+    ];
+
+    for path in &fallbacks {
+        if path.exists() && !paths.contains(path) {
+            paths.push(path.clone());
+        }
+    }
+
+    paths
 }
 
 fn dirs_home() -> PathBuf {
@@ -350,6 +435,19 @@ mod tests {
         let config = Config::default();
         assert!(!config.vulncheck.enabled);
         assert!(!config.versioncheck.enabled);
+    }
+
+    #[test]
+    fn probe_yarn_cache_handles_missing_tool() {
+        // yarn may not be installed — just verify no panic
+        let paths = probe_yarn_paths();
+        let _ = paths;
+    }
+
+    #[test]
+    fn probe_pnpm_cache_handles_missing_tool() {
+        let paths = probe_pnpm_paths();
+        let _ = paths;
     }
 
     #[cfg(feature = "mcp")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,7 +258,7 @@ fn probe_yarn_paths() -> Vec<PathBuf> {
     let macos_fallbacks: [PathBuf; 0] = [];
 
     for path in fallbacks.iter().chain(macos_fallbacks.iter()) {
-        if path.exists() && !paths.contains(path) {
+        if path.exists() && !paths.contains(path) && !is_ancestor_or_descendant(path, &paths) {
             paths.push(path.clone());
         }
     }
@@ -279,7 +279,10 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
             let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
             let path = PathBuf::from(&path_str);
             if path.exists() {
-                paths.push(path);
+                // `pnpm store path` returns e.g. .../store/v10; go up to `store`
+                // so the tree shows the full store hierarchy.
+                let root = path.parent().unwrap_or(&path);
+                paths.push(root.to_path_buf());
             }
         }
     }
@@ -298,6 +301,13 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+/// Returns true if `candidate` is an ancestor or descendant of any path in `existing`.
+fn is_ancestor_or_descendant(candidate: &Path, existing: &[PathBuf]) -> bool {
+    existing
+        .iter()
+        .any(|p| candidate.starts_with(p) || p.starts_with(candidate))
 }
 
 fn dirs_home() -> PathBuf {

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,7 +281,10 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
             if path.exists() {
                 // `pnpm store path` returns e.g. .../store/v10; go up to `store`
                 // so the tree shows the full store hierarchy.
-                let root = path.parent().unwrap_or(&path);
+                let root = path
+                    .parent()
+                    .filter(|p| p.parent().is_some()) // reject "/" or ""
+                    .unwrap_or(&path);
                 paths.push(root.to_path_buf());
             }
         }
@@ -295,7 +298,7 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
     ];
 
     for path in &fallbacks {
-        if path.exists() && !paths.contains(path) {
+        if path.exists() && !paths.contains(path) && !is_ancestor_or_descendant(path, &paths) {
             paths.push(path.clone());
         }
     }
@@ -503,6 +506,47 @@ mod tests {
     fn probe_pnpm_cache_handles_missing_tool() {
         let paths = probe_pnpm_paths();
         let _ = paths;
+    }
+
+    #[test]
+    fn ancestor_or_descendant_child_detected() {
+        let existing = vec![PathBuf::from("/home/user/Library/Caches/Yarn")];
+        assert!(is_ancestor_or_descendant(
+            Path::new("/home/user/Library/Caches/Yarn/v6"),
+            &existing
+        ));
+    }
+
+    #[test]
+    fn ancestor_or_descendant_parent_detected() {
+        let existing = vec![PathBuf::from("/home/user/Library/Caches/Yarn/v6")];
+        assert!(is_ancestor_or_descendant(
+            Path::new("/home/user/Library/Caches/Yarn"),
+            &existing
+        ));
+    }
+
+    #[test]
+    fn ancestor_or_descendant_sibling_not_detected() {
+        let existing = vec![PathBuf::from("/home/user/.npm")];
+        assert!(!is_ancestor_or_descendant(
+            Path::new("/home/user/.yarn"),
+            &existing
+        ));
+    }
+
+    #[test]
+    fn ancestor_or_descendant_empty_list() {
+        assert!(!is_ancestor_or_descendant(Path::new("/any/path"), &[]));
+    }
+
+    #[test]
+    fn ancestor_or_descendant_exact_match() {
+        let existing = vec![PathBuf::from("/home/user/.npm")];
+        assert!(is_ancestor_or_descendant(
+            Path::new("/home/user/.npm"),
+            &existing
+        ));
     }
 
     #[cfg(feature = "mcp")]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -88,6 +88,11 @@ pub fn detect(path: &Path) -> CacheKind {
                     return CacheKind::Pnpm;
                 }
             }
+            "pnpm" => {
+                if path.to_string_lossy().contains("store") {
+                    return CacheKind::Pnpm;
+                }
+            }
             ".yarn-cache" | "Yarn" => return CacheKind::Yarn,
             ".yarn" => {
                 if path.to_string_lossy().contains(".yarn/cache")
@@ -386,6 +391,16 @@ mod tests {
     fn detect_pnpm_virtual_store() {
         assert_eq!(
             detect(&PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21")),
+            CacheKind::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_pnpm_xdg_store() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.local/share/pnpm/store/v3/files/ab"
+            )),
             CacheKind::Pnpm
         );
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,6 +6,7 @@ pub mod homebrew;
 pub mod huggingface;
 pub mod npm;
 pub mod pip;
+pub mod pnpm;
 pub mod pre_commit;
 pub mod prisma;
 pub mod torch;
@@ -69,6 +70,8 @@ pub fn detect(path: &Path) -> CacheKind {
         "prisma" => return CacheKind::Prisma,
         ".npm" | "npm" => return CacheKind::Npm,
         ".yarn-cache" => return CacheKind::Yarn,
+        ".pnpm-store" => return CacheKind::Pnpm,
+        ".pnpm" => return CacheKind::Pnpm,
         _ => {}
     }
 
@@ -79,6 +82,12 @@ pub fn detect(path: &Path) -> CacheKind {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
         match ancestor_name.as_str() {
+            ".pnpm-store" => return CacheKind::Pnpm,
+            ".pnpm" => {
+                if ancestor.to_string_lossy().contains("node_modules") {
+                    return CacheKind::Pnpm;
+                }
+            }
             ".yarn-cache" | "Yarn" => return CacheKind::Yarn,
             ".yarn" => {
                 if path.to_string_lossy().contains(".yarn/cache")
@@ -136,7 +145,7 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Chroma => chroma::semantic_name(path),
         CacheKind::Prisma => prisma::semantic_name(path),
         CacheKind::Yarn => yarn::semantic_name(path),
-        CacheKind::Pnpm => None,
+        CacheKind::Pnpm => pnpm::semantic_name(path),
         CacheKind::Unknown => None,
     }
 }
@@ -157,7 +166,7 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Chroma => chroma::metadata(path),
         CacheKind::Prisma => prisma::metadata(path),
         CacheKind::Yarn => yarn::metadata(path),
-        CacheKind::Pnpm => generic::metadata(path),
+        CacheKind::Pnpm => pnpm::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
 }
@@ -176,6 +185,7 @@ pub fn package_id(kind: CacheKind, path: &Path) -> Option<PackageId> {
         CacheKind::Npm => npm::package_id(path),
         CacheKind::Cargo => cargo::package_id(path),
         CacheKind::Yarn => yarn::package_id(path),
+        CacheKind::Pnpm => pnpm::package_id(path),
         _ => None,
     }
 }
@@ -198,13 +208,21 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
         CacheKind::Npm => Some(format!("npm install {name}@{version}")),
         CacheKind::Cargo => Some(format!("cargo update -p {name}")),
         CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
+        CacheKind::Pnpm => Some(format!("pnpm add {name}@{version}")),
         _ => None,
     }
 }
 
 /// Get safety level for deletion.
-pub fn safety(kind: CacheKind, _path: &Path) -> SafetyLevel {
+pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
     match kind {
+        CacheKind::Pnpm => {
+            if path.to_string_lossy().contains("node_modules/.pnpm") {
+                SafetyLevel::Caution
+            } else {
+                SafetyLevel::Safe
+            }
+        }
         CacheKind::Unknown => SafetyLevel::Caution,
         _ => SafetyLevel::Safe,
     }
@@ -356,6 +374,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detect_pnpm_store() {
+        assert_eq!(
+            detect(&PathBuf::from("/home/user/.pnpm-store/v3/files/ab/cd")),
+            CacheKind::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_pnpm_virtual_store() {
+        assert_eq!(
+            detect(&PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21")),
+            CacheKind::Pnpm
+        );
+    }
+
     // --- semantic_name() dispatch ---
 
     #[test]
@@ -400,7 +434,21 @@ mod tests {
         assert_eq!(safety(CacheKind::Chroma, &path), SafetyLevel::Safe);
         assert_eq!(safety(CacheKind::Prisma, &path), SafetyLevel::Safe);
         assert_eq!(safety(CacheKind::Yarn, &path), SafetyLevel::Safe);
-        assert_eq!(safety(CacheKind::Pnpm, &path), SafetyLevel::Safe);
+        assert_eq!(
+            safety(CacheKind::Pnpm, &PathBuf::from("/home/.pnpm-store/v3")),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_pnpm_virtual_store_is_caution() {
+        assert_eq!(
+            safety(
+                CacheKind::Pnpm,
+                &PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21")
+            ),
+            SafetyLevel::Caution
+        );
     }
 
     #[test]
@@ -478,6 +526,14 @@ mod tests {
     }
 
     #[test]
+    fn upgrade_command_pnpm() {
+        assert_eq!(
+            upgrade_command(CacheKind::Pnpm, "lodash", "4.17.21"),
+            Some("pnpm add lodash@4.17.21".to_string())
+        );
+    }
+
+    #[test]
     fn upgrade_command_unsupported_kinds_return_none() {
         let unsupported = [
             CacheKind::HuggingFace,
@@ -488,7 +544,6 @@ mod tests {
             CacheKind::Torch,
             CacheKind::Chroma,
             CacheKind::Prisma,
-            CacheKind::Pnpm,
         ];
         for kind in unsupported {
             assert_eq!(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -380,6 +380,15 @@ mod tests {
     }
 
     #[test]
+    fn detect_yarn_releases_is_not_yarn_cache() {
+        // .yarn/releases should NOT be detected as Yarn cache
+        assert_eq!(
+            detect(&PathBuf::from("/project/.yarn/releases/yarn-4.0.cjs")),
+            CacheKind::Unknown
+        );
+    }
+
+    #[test]
     fn detect_pnpm_store() {
         assert_eq!(
             detect(&PathBuf::from("/home/user/.pnpm-store/v3/files/ab/cd")),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -68,6 +68,7 @@ pub fn detect(path: &Path) -> CacheKind {
         "chroma" => return CacheKind::Chroma,
         "prisma" => return CacheKind::Prisma,
         ".npm" | "npm" => return CacheKind::Npm,
+        ".yarn-cache" => return CacheKind::Yarn,
         _ => {}
     }
 
@@ -78,6 +79,24 @@ pub fn detect(path: &Path) -> CacheKind {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
         match ancestor_name.as_str() {
+            ".yarn-cache" | "Yarn" => return CacheKind::Yarn,
+            ".yarn" => {
+                if path.to_string_lossy().contains(".yarn/cache")
+                    || path.to_string_lossy().contains(".yarn\\cache")
+                {
+                    return CacheKind::Yarn;
+                }
+            }
+            "yarn" => {
+                // ~/.cache/yarn/ is Classic
+                if ancestor.to_string_lossy().contains(".cache") {
+                    return CacheKind::Yarn;
+                }
+                // yarn/berry/cache is Berry global
+                if path.to_string_lossy().contains("berry/cache") {
+                    return CacheKind::Yarn;
+                }
+            }
             "huggingface" => return CacheKind::HuggingFace,
             "pip" => return CacheKind::Pip,
             "uv" => return CacheKind::Uv,
@@ -116,7 +135,7 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Torch => torch::semantic_name(path),
         CacheKind::Chroma => chroma::semantic_name(path),
         CacheKind::Prisma => prisma::semantic_name(path),
-        CacheKind::Yarn => None,
+        CacheKind::Yarn => yarn::semantic_name(path),
         CacheKind::Pnpm => None,
         CacheKind::Unknown => None,
     }
@@ -137,7 +156,7 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Torch => torch::metadata(path),
         CacheKind::Chroma => chroma::metadata(path),
         CacheKind::Prisma => prisma::metadata(path),
-        CacheKind::Yarn => generic::metadata(path),
+        CacheKind::Yarn => yarn::metadata(path),
         CacheKind::Pnpm => generic::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
@@ -156,6 +175,7 @@ pub fn package_id(kind: CacheKind, path: &Path) -> Option<PackageId> {
         CacheKind::Pip => pip::package_id(path),
         CacheKind::Npm => npm::package_id(path),
         CacheKind::Cargo => cargo::package_id(path),
+        CacheKind::Yarn => yarn::package_id(path),
         _ => None,
     }
 }
@@ -177,6 +197,7 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
         CacheKind::Uv => Some(format!("uv pip install {name}>={version}")),
         CacheKind::Npm => Some(format!("npm install {name}@{version}")),
         CacheKind::Cargo => Some(format!("cargo update -p {name}")),
+        CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
         _ => None,
     }
 }
@@ -297,6 +318,44 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detect_yarn_classic_cache() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.yarn-cache/v6/npm-lodash-4.17.21-abc.tgz"
+            )),
+            CacheKind::Yarn
+        );
+    }
+
+    #[test]
+    fn detect_yarn_xdg_cache() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.cache/yarn/v6/npm-express-4.21.0-def.tgz"
+            )),
+            CacheKind::Yarn
+        );
+    }
+
+    #[test]
+    fn detect_yarn_berry_cache() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/project/.yarn/cache/lodash-npm-4.17.21-abc.zip"
+            )),
+            CacheKind::Yarn
+        );
+    }
+
+    #[test]
+    fn detect_yarn_macos_library() {
+        assert_eq!(
+            detect(&PathBuf::from("/Users/me/Library/Caches/Yarn/v6")),
+            CacheKind::Yarn
+        );
+    }
+
     // --- semantic_name() dispatch ---
 
     #[test]
@@ -411,6 +470,14 @@ mod tests {
     }
 
     #[test]
+    fn upgrade_command_yarn() {
+        assert_eq!(
+            upgrade_command(CacheKind::Yarn, "lodash", "4.17.21"),
+            Some("yarn add lodash@4.17.21".to_string())
+        );
+    }
+
+    #[test]
     fn upgrade_command_unsupported_kinds_return_none() {
         let unsupported = [
             CacheKind::HuggingFace,
@@ -421,7 +488,6 @@ mod tests {
             CacheKind::Torch,
             CacheKind::Chroma,
             CacheKind::Prisma,
-            CacheKind::Yarn,
             CacheKind::Pnpm,
         ];
         for kind in unsupported {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -115,6 +115,8 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Torch => torch::semantic_name(path),
         CacheKind::Chroma => chroma::semantic_name(path),
         CacheKind::Prisma => prisma::semantic_name(path),
+        CacheKind::Yarn => None,
+        CacheKind::Pnpm => None,
         CacheKind::Unknown => None,
     }
 }
@@ -134,6 +136,8 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Torch => torch::metadata(path),
         CacheKind::Chroma => chroma::metadata(path),
         CacheKind::Prisma => prisma::metadata(path),
+        CacheKind::Yarn => generic::metadata(path),
+        CacheKind::Pnpm => generic::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
 }
@@ -335,6 +339,8 @@ mod tests {
         assert_eq!(safety(CacheKind::Torch, &path), SafetyLevel::Safe);
         assert_eq!(safety(CacheKind::Chroma, &path), SafetyLevel::Safe);
         assert_eq!(safety(CacheKind::Prisma, &path), SafetyLevel::Safe);
+        assert_eq!(safety(CacheKind::Yarn, &path), SafetyLevel::Safe);
+        assert_eq!(safety(CacheKind::Pnpm, &path), SafetyLevel::Safe);
     }
 
     #[test]
@@ -414,6 +420,8 @@ mod tests {
             CacheKind::Torch,
             CacheKind::Chroma,
             CacheKind::Prisma,
+            CacheKind::Yarn,
+            CacheKind::Pnpm,
         ];
         for kind in unsupported {
             assert_eq!(

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -230,7 +230,8 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
         }
         CacheKind::Yarn => {
             // Berry project-local caches (.yarn/cache/) may be committed to git (zero-install)
-            if path.to_string_lossy().contains(".yarn/cache") {
+            let path_str = path.to_string_lossy();
+            if path_str.contains(".yarn/cache") || path_str.contains(".yarn\\cache") {
                 SafetyLevel::Caution
             } else {
                 SafetyLevel::Safe

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,6 +11,7 @@ pub mod prisma;
 pub mod torch;
 pub mod uv;
 pub mod whisper;
+pub mod yarn;
 
 use crate::tree::node::CacheKind;
 use std::path::Path;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -208,8 +208,8 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
         return None;
     }
     match kind {
-        CacheKind::Pip => Some(format!("pip install {name}>={version}")),
-        CacheKind::Uv => Some(format!("uv pip install {name}>={version}")),
+        CacheKind::Pip => Some(format!("pip install '{name}>={version}'")),
+        CacheKind::Uv => Some(format!("uv pip install '{name}>={version}'")),
         CacheKind::Npm => Some(format!("npm install {name}@{version}")),
         CacheKind::Cargo => Some(format!("cargo update -p {name}")),
         CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
@@ -223,6 +223,14 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
     match kind {
         CacheKind::Pnpm => {
             if path.to_string_lossy().contains("node_modules/.pnpm") {
+                SafetyLevel::Caution
+            } else {
+                SafetyLevel::Safe
+            }
+        }
+        CacheKind::Yarn => {
+            // Berry project-local caches (.yarn/cache/) may be committed to git (zero-install)
+            if path.to_string_lossy().contains(".yarn/cache") {
                 SafetyLevel::Caution
             } else {
                 SafetyLevel::Safe
@@ -483,6 +491,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn safety_yarn_berry_project_local_is_caution() {
+        assert_eq!(
+            safety(
+                CacheKind::Yarn,
+                &PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-abc.zip")
+            ),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_yarn_classic_global_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Yarn,
+                &PathBuf::from("/home/user/.cache/yarn/v6/npm-lodash-4.17.21-abc-integrity")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
     // --- SafetyLevel ---
 
     #[test]
@@ -508,7 +538,7 @@ mod tests {
     fn upgrade_command_pip() {
         assert_eq!(
             upgrade_command(CacheKind::Pip, "requests", "2.32.0"),
-            Some("pip install requests>=2.32.0".to_string())
+            Some("pip install 'requests>=2.32.0'".to_string())
         );
     }
 
@@ -516,7 +546,7 @@ mod tests {
     fn upgrade_command_uv() {
         assert_eq!(
             upgrade_command(CacheKind::Uv, "flask", "3.1.0"),
-            Some("uv pip install flask>=3.1.0".to_string())
+            Some("uv pip install 'flask>=3.1.0'".to_string())
         );
     }
 
@@ -632,7 +662,7 @@ mod tests {
     fn upgrade_command_allows_dotted_names() {
         assert_eq!(
             upgrade_command(CacheKind::Pip, "python-dateutil", "2.9.0"),
-            Some("pip install python-dateutil>=2.9.0".to_string())
+            Some("pip install 'python-dateutil>=2.9.0'".to_string())
         );
     }
 
@@ -640,7 +670,7 @@ mod tests {
     fn upgrade_command_allows_underscored_names() {
         assert_eq!(
             upgrade_command(CacheKind::Pip, "typing_extensions", "4.12.0"),
-            Some("pip install typing_extensions>=4.12.0".to_string())
+            Some("pip install 'typing_extensions>=4.12.0'".to_string())
         );
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -695,4 +695,166 @@ mod tests {
         assert!(!is_safe_for_shell("a\nb"));
         assert!(!is_safe_for_shell(""));
     }
+
+    // =================================================================
+    // Adversarial tests — detection collisions & cross-provider edge cases
+    // =================================================================
+
+    // --- Detection collisions: can a path match the wrong provider? ---
+
+    #[test]
+    fn detect_pnpm_inside_npm_cache_is_pnpm() {
+        // node_modules/.pnpm inside an .npm root — pnpm should win
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.npm/node_modules/.pnpm/lodash@4.17.21"
+            )),
+            CacheKind::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_npm_node_modules_not_pnpm() {
+        // Plain node_modules (no .pnpm) under .npm — should be npm, not pnpm
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.npm/_npx/abc/node_modules/lodash"
+            )),
+            CacheKind::Npm
+        );
+    }
+
+    #[test]
+    fn detect_yarn_dot_yarn_plugins_not_cache() {
+        // .yarn/plugins — NOT a cache directory
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/project/.yarn/plugins/@yarnpkg/plugin-compat.cjs"
+            )),
+            CacheKind::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_yarn_dot_yarn_unplugged_not_cache() {
+        // .yarn/unplugged — NOT a cache directory
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/project/.yarn/unplugged/esbuild-npm-0.19.0/node_modules"
+            )),
+            CacheKind::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_pnpm_dir_outside_node_modules_is_unknown() {
+        // .pnpm ancestor WITHOUT node_modules → Unknown, not Pnpm
+        // The ancestor walk requires "node_modules" in the path for .pnpm
+        // Only the direct name ".pnpm" matches unconditionally
+        assert_eq!(
+            detect(&PathBuf::from("/project/.pnpm/something")),
+            CacheKind::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_pnpm_direct_name_match() {
+        // When the file IS named .pnpm (not a child of it), direct match fires
+        assert_eq!(
+            detect(&PathBuf::from("/project/node_modules/.pnpm")),
+            CacheKind::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_yarn_inside_pnpm_store() {
+        // Unlikely: a "yarn" dir inside pnpm store — pnpm should win (earlier in walk)
+        assert_eq!(
+            detect(&PathBuf::from("/home/user/.pnpm-store/v3/yarn/something")),
+            CacheKind::Pnpm
+        );
+    }
+
+    #[test]
+    fn detect_npm_named_dir_inside_yarn_cache_matches_npm() {
+        // "npm" dir inside Yarn Classic cache — the ancestor walk finds "npm"
+        // in the dir name before reaching "yarn" higher up. This is a known
+        // quirk: the deepest matching ancestor wins. In practice this path
+        // (node_modules/npm inside a Yarn cache entry) is the npm CLI package
+        // itself, and detecting it as Npm is arguably correct.
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.cache/yarn/v6/npm-lodash-4.17.21-abc-integrity/node_modules/npm"
+            )),
+            CacheKind::Npm
+        );
+    }
+
+    // --- Safety: adversarial paths ---
+
+    #[test]
+    fn safety_yarn_berry_nested_deep() {
+        // Deep path inside Berry cache — still Caution
+        assert_eq!(
+            safety(
+                CacheKind::Yarn,
+                &PathBuf::from("/project/.yarn/cache/node_modules/@babel/core/index.js")
+            ),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_yarn_library_caches_is_safe() {
+        // macOS global cache — Safe (not project-local)
+        assert_eq!(
+            safety(
+                CacheKind::Yarn,
+                &PathBuf::from("/Users/me/Library/Caches/Yarn/v6/npm-lodash-abc-integrity")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_pnpm_store_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Pnpm,
+                &PathBuf::from("/home/user/.pnpm-store/v3/files/ab/cd")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    // --- upgrade_command: Yarn/pnpm with scoped packages ---
+
+    #[test]
+    fn upgrade_command_yarn_scoped() {
+        assert_eq!(
+            upgrade_command(CacheKind::Yarn, "@babel/core", "7.24.0"),
+            Some("yarn add @babel/core@7.24.0".to_string())
+        );
+    }
+
+    #[test]
+    fn upgrade_command_pnpm_scoped() {
+        assert_eq!(
+            upgrade_command(CacheKind::Pnpm, "@types/node", "22.0.0"),
+            Some("pnpm add @types/node@22.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn upgrade_command_yarn_rejects_injection() {
+        assert_eq!(
+            upgrade_command(CacheKind::Yarn, "lodash; rm -rf /", "4.17.21"),
+            None
+        );
+    }
+
+    #[test]
+    fn upgrade_command_pnpm_rejects_injection() {
+        assert_eq!(upgrade_command(CacheKind::Pnpm, "$(whoami)", "1.0.0"), None);
+    }
 }

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -186,7 +186,16 @@ fn parse_index_filename(filename: &str) -> Option<super::PackageId> {
         return None;
     }
 
-    let name = raw_name.replace('+', "/");
+    // Only replace '+' with '/' for scoped packages (@scope+name → @scope/name)
+    let name = if raw_name.starts_with('@') {
+        if let Some(pos) = raw_name.find('+') {
+            format!("{}/{}", &raw_name[..pos], &raw_name[pos + 1..])
+        } else {
+            raw_name.to_string()
+        }
+    } else {
+        raw_name.to_string()
+    };
 
     Some(super::PackageId {
         ecosystem: "npm",
@@ -420,6 +429,78 @@ mod tests {
             "/Users/julien/Library/pnpm/store/v10/files/61/9a372bcd920fb462ca2d04d4440fa2",
         );
         assert_eq!(package_id(&path), None);
+    }
+
+    // --- parse_index_filename rejection cases ---
+
+    #[test]
+    fn parse_index_short_hash_returns_none() {
+        assert_eq!(parse_index_filename("abcd-lodash@1.0.0.json"), None);
+    }
+
+    #[test]
+    fn parse_index_non_hex_hash_returns_none() {
+        let bad = format!(
+            "{}z-lodash@1.0.0.json",
+            "g".repeat(61) // 'g' is not a hex digit
+        );
+        assert_eq!(parse_index_filename(&bad), None);
+    }
+
+    #[test]
+    fn parse_index_missing_separator_returns_none() {
+        // 62 hex chars followed by 'X' instead of '-'
+        let bad = format!("{}Xlodash@1.0.0.json", "a".repeat(62));
+        assert_eq!(parse_index_filename(&bad), None);
+    }
+
+    #[test]
+    fn parse_index_non_numeric_version_returns_none() {
+        let bad = format!("{}-lodash@latest.json", "a".repeat(62));
+        assert_eq!(parse_index_filename(&bad), None);
+    }
+
+    #[test]
+    fn parse_index_empty_name_returns_none() {
+        let bad = format!("{}-@1.0.0.json", "a".repeat(62));
+        assert_eq!(parse_index_filename(&bad), None);
+    }
+
+    #[test]
+    fn parse_index_no_json_suffix_returns_none() {
+        let bad = format!("{}-lodash@1.0.0", "a".repeat(62));
+        assert_eq!(parse_index_filename(&bad), None);
+    }
+
+    #[test]
+    fn parse_index_unscoped_plus_preserved() {
+        // A hypothetical unscoped name with '+' should NOT have it replaced
+        let filename = format!("{}-c++parser@1.0.0.json", "a".repeat(62));
+        let id = parse_index_filename(&filename).unwrap();
+        assert_eq!(id.name, "c++parser");
+    }
+
+    // --- semantic_name for index ---
+
+    #[test]
+    fn semantic_name_package_index_dir() {
+        let path = PathBuf::from("/Users/julien/Library/pnpm/store/v10/index");
+        assert_eq!(semantic_name(&path), Some("Package Index".into()));
+    }
+
+    #[test]
+    fn semantic_name_index_file() {
+        let path = PathBuf::from(format!(
+            "/Users/julien/Library/pnpm/store/v10/index/3e/{}-lodash@4.17.20.json",
+            "a".repeat(62)
+        ));
+        assert_eq!(semantic_name(&path), Some("lodash 4.17.20".into()));
+    }
+
+    #[test]
+    fn semantic_name_store_version_non_numeric_returns_none() {
+        let path = PathBuf::from("/home/user/.pnpm-store/vfoo");
+        assert_eq!(semantic_name(&path), None);
     }
 
     // --- Metadata ---

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -94,8 +94,10 @@ pub fn semantic_name(path: &Path) -> Option<String> {
 
     // Subdirectories inside the content store
     if path_str.contains(".pnpm-store") || path_str.contains("pnpm/store") {
-        if name == "v3" {
-            return Some("Store v3".to_string());
+        if let Some(version) = name.strip_prefix('v') {
+            if version.chars().all(|c| c.is_ascii_digit()) {
+                return Some(format!("Store v{version}"));
+            }
         }
         if name == "files" {
             return Some("Content Files".to_string());
@@ -267,9 +269,15 @@ mod tests {
     }
 
     #[test]
-    fn semantic_name_store_version() {
+    fn semantic_name_store_version_v3() {
         let path = PathBuf::from("/home/user/.pnpm-store/v3");
         assert_eq!(semantic_name(&path), Some("Store v3".into()));
+    }
+
+    #[test]
+    fn semantic_name_store_version_v10() {
+        let path = PathBuf::from("/Users/julien/Library/pnpm/store/v10");
+        assert_eq!(semantic_name(&path), Some("Store v10".into()));
     }
 
     #[test]
@@ -578,11 +586,9 @@ mod tests {
     }
 
     #[test]
-    fn semantic_name_store_v4_not_recognized() {
-        // semantic_name only recognizes "v3" specifically — future versions
-        // would need a code update. This documents current behavior.
+    fn semantic_name_store_v4_recognized() {
         let path = PathBuf::from("/home/user/.pnpm-store/v4");
-        assert_eq!(semantic_name(&path), None);
+        assert_eq!(semantic_name(&path), Some("Store v4".into()));
     }
 
     // --- metadata: adversarial ---

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -21,23 +21,62 @@ pub fn is_pnpm_virtual_store(path: &Path) -> bool {
 /// - `"lodash@4.17.21"` → `("lodash", "4.17.21")`
 /// - `"@babel+core@7.24.0"` → `("@babel/core", "7.24.0")`
 /// - `"@types+node@22.0.0"` → `("@types/node", "22.0.0")`
+/// - `"react-dom@18.2.0_react@18.2.0"` → `("react-dom", "18.2.0")`
 pub fn parse_virtual_store_name(dir_name: &str) -> Option<(String, String)> {
+    // pnpm v9+ appends peer dependency info after '_':
+    // e.g., "react-dom@18.2.0_react@18.2.0"
+    // Strip everything after the first '_' that follows a version.
+    let base = strip_peer_deps(dir_name);
+
     // Find the last '@' which separates name from version
-    let at_pos = dir_name.rfind('@')?;
-    let version = &dir_name[at_pos + 1..];
+    let at_pos = base.rfind('@')?;
+    let version = &base[at_pos + 1..];
 
     if version.is_empty() {
         return None;
     }
 
-    let raw_name = &dir_name[..at_pos];
+    let raw_name = &base[..at_pos];
     if raw_name.is_empty() {
         return None;
     }
 
     // Convert '+' back to '/' for scoped packages: @babel+core → @babel/core
     let name = raw_name.replace('+', "/");
+
+    // Reject degenerate names like bare "@"
+    if name == "@" {
+        return None;
+    }
+
     Some((name, version.to_string()))
+}
+
+/// Strip peer dependency suffix from a pnpm virtual store directory name.
+/// pnpm uses '_' to separate the base package from peer deps:
+/// `react-dom@18.2.0_react@18.2.0` → `react-dom@18.2.0`
+/// But scoped packages use '+' not '_' for the scope separator,
+/// so `_` always indicates peer deps in practice.
+fn strip_peer_deps(dir_name: &str) -> &str {
+    // Find the version '@': for scoped packages, skip the leading '@'
+    let search_start = if let Some(after_at) = dir_name.strip_prefix('@') {
+        // Find the second '@' (version delimiter)
+        match after_at.find('@') {
+            Some(pos) => pos + 1, // position in dir_name
+            None => return dir_name,
+        }
+    } else {
+        match dir_name.find('@') {
+            Some(pos) => pos,
+            None => return dir_name,
+        }
+    };
+
+    // Now look for '_' after the version '@'
+    match dir_name[search_start..].find('_') {
+        Some(pos) => &dir_name[..search_start + pos],
+        None => dir_name,
+    }
 }
 
 pub fn semantic_name(path: &Path) -> Option<String> {
@@ -64,7 +103,7 @@ pub fn semantic_name(path: &Path) -> Option<String> {
     }
 
     // Virtual store entries: name@version directories
-    if name.contains('@') {
+    if name.contains('@') && is_pnpm_virtual_store(path) {
         if let Some((pkg, ver)) = parse_virtual_store_name(&name) {
             return Some(format!("{} {}", pkg, ver));
         }
@@ -316,5 +355,59 @@ mod tests {
                 .iter()
                 .any(|f| f.label == "Type" && f.value == "Content-addressed store")
         );
+    }
+
+    // --- Peer dependency handling ---
+
+    #[test]
+    fn parse_with_peer_deps() {
+        let (name, ver) = parse_virtual_store_name("react-dom@18.2.0_react@18.2.0").unwrap();
+        assert_eq!(name, "react-dom");
+        assert_eq!(ver, "18.2.0");
+    }
+
+    #[test]
+    fn parse_scoped_with_peer_deps() {
+        let (name, ver) =
+            parse_virtual_store_name("@babel+core@7.24.0_@babel+preset-env@7.24.0").unwrap();
+        assert_eq!(name, "@babel/core");
+        assert_eq!(ver, "7.24.0");
+    }
+
+    #[test]
+    fn parse_with_multiple_peer_deps() {
+        let (name, ver) =
+            parse_virtual_store_name("eslint-plugin-react@7.35.0_eslint@9.0.0_typescript@5.0.0")
+                .unwrap();
+        assert_eq!(name, "eslint-plugin-react");
+        assert_eq!(ver, "7.35.0");
+    }
+
+    #[test]
+    fn parse_malformed_at_only() {
+        // Just "@" as name — should return None
+        assert!(parse_virtual_store_name("@@1.0.0").is_none());
+    }
+
+    #[test]
+    fn package_id_with_non_numeric_version() {
+        // pnpm can have @latest or @next in some contexts
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@latest");
+        assert!(package_id(&path).is_none());
+    }
+
+    #[test]
+    fn package_id_with_peer_deps() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "react-dom");
+        assert_eq!(id.version, "18.2.0");
+    }
+
+    #[test]
+    fn semantic_name_at_dir_outside_virtual_store() {
+        // A directory with @ in name but NOT in node_modules/.pnpm
+        let path = PathBuf::from("/home/user/.pnpm-store/v3/foo@1.0.0");
+        assert_eq!(semantic_name(&path), None);
     }
 }

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -1,0 +1,320 @@
+use super::MetadataField;
+use std::path::Path;
+
+/// Returns true if the path is within a known pnpm cache/store location.
+#[allow(dead_code)]
+pub fn is_pnpm_cache(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains(".pnpm-store")
+        || path_str.contains("pnpm/store")
+        || path_str.contains("node_modules/.pnpm")
+}
+
+/// Returns true if the path is within the pnpm virtual store (node_modules/.pnpm).
+pub fn is_pnpm_virtual_store(path: &Path) -> bool {
+    path.to_string_lossy().contains("node_modules/.pnpm")
+}
+
+/// Parse a pnpm virtual store directory name into (name, version).
+///
+/// Examples:
+/// - `"lodash@4.17.21"` → `("lodash", "4.17.21")`
+/// - `"@babel+core@7.24.0"` → `("@babel/core", "7.24.0")`
+/// - `"@types+node@22.0.0"` → `("@types/node", "22.0.0")`
+pub fn parse_virtual_store_name(dir_name: &str) -> Option<(String, String)> {
+    // Find the last '@' which separates name from version
+    let at_pos = dir_name.rfind('@')?;
+    let version = &dir_name[at_pos + 1..];
+
+    if version.is_empty() {
+        return None;
+    }
+
+    let raw_name = &dir_name[..at_pos];
+    if raw_name.is_empty() {
+        return None;
+    }
+
+    // Convert '+' back to '/' for scoped packages: @babel+core → @babel/core
+    let name = raw_name.replace('+', "/");
+    Some((name, version.to_string()))
+}
+
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+    let path_str = path.to_string_lossy();
+
+    // Top-level store directories
+    if name == ".pnpm-store" {
+        return Some("pnpm Content Store".to_string());
+    }
+
+    if name == ".pnpm" {
+        return Some("pnpm Virtual Store".to_string());
+    }
+
+    // Subdirectories inside the content store
+    if path_str.contains(".pnpm-store") || path_str.contains("pnpm/store") {
+        if name == "v3" {
+            return Some("Store v3".to_string());
+        }
+        if name == "files" {
+            return Some("Content Files".to_string());
+        }
+    }
+
+    // Virtual store entries: name@version directories
+    if name.contains('@') {
+        if let Some((pkg, ver)) = parse_virtual_store_name(&name) {
+            return Some(format!("{} {}", pkg, ver));
+        }
+    }
+
+    None
+}
+
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    // Only for virtual store entries
+    if !is_pnpm_virtual_store(path) {
+        return None;
+    }
+
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Must contain '@' to be a name@version entry
+    if !name.contains('@') {
+        return None;
+    }
+
+    let (pkg, ver) = parse_virtual_store_name(&name)?;
+
+    // Version must start with a digit
+    if !ver
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    Some(super::PackageId {
+        ecosystem: "npm",
+        name: pkg,
+        version: ver,
+    })
+}
+
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let path_str = path.to_string_lossy();
+
+    // Top-level store and virtual store dirs: count entries
+    if name == ".pnpm-store" || name == ".pnpm" {
+        if let Ok(entries) = std::fs::read_dir(path) {
+            let count = entries.filter_map(|e| e.ok()).count();
+            fields.push(MetadataField {
+                label: "Entries".to_string(),
+                value: count.to_string(),
+            });
+        }
+        return fields;
+    }
+
+    // Inside content store
+    if path_str.contains(".pnpm-store") || path_str.contains("pnpm/store") {
+        fields.push(MetadataField {
+            label: "Type".to_string(),
+            value: "Content-addressed store".to_string(),
+        });
+        return fields;
+    }
+
+    // Virtual store entries with @
+    if name.contains('@') && is_pnpm_virtual_store(path) {
+        fields.push(MetadataField {
+            label: "Type".to_string(),
+            value: "Virtual store entry".to_string(),
+        });
+        return fields;
+    }
+
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- Detection ---
+
+    #[test]
+    fn detects_pnpm_store() {
+        assert!(is_pnpm_cache(&PathBuf::from("/home/user/.pnpm-store/v3")));
+    }
+
+    #[test]
+    fn detects_pnpm_virtual_store() {
+        assert!(is_pnpm_cache(&PathBuf::from(
+            "/project/node_modules/.pnpm/lodash@4.17.21"
+        )));
+    }
+
+    #[test]
+    fn detects_xdg_pnpm_store() {
+        assert!(is_pnpm_cache(&PathBuf::from(
+            "/home/user/.local/share/pnpm/store/v3"
+        )));
+    }
+
+    #[test]
+    fn does_not_detect_unrelated_path() {
+        assert!(!is_pnpm_cache(&PathBuf::from("/home/user/.npm/_cacache")));
+    }
+
+    // --- Parsing ---
+
+    #[test]
+    fn parse_unscoped_package() {
+        assert_eq!(
+            parse_virtual_store_name("lodash@4.17.21"),
+            Some(("lodash".to_string(), "4.17.21".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_scoped_package() {
+        assert_eq!(
+            parse_virtual_store_name("@babel+core@7.24.0"),
+            Some(("@babel/core".to_string(), "7.24.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_scoped_types() {
+        assert_eq!(
+            parse_virtual_store_name("@types+node@22.0.0"),
+            Some(("@types/node".to_string(), "22.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_empty_version_returns_none() {
+        assert_eq!(parse_virtual_store_name("lodash@"), None);
+    }
+
+    #[test]
+    fn parse_no_at_returns_none() {
+        assert_eq!(parse_virtual_store_name("lodash"), None);
+    }
+
+    // --- Semantic name ---
+
+    #[test]
+    fn semantic_name_pnpm_store() {
+        let path = PathBuf::from("/home/user/.pnpm-store");
+        assert_eq!(semantic_name(&path), Some("pnpm Content Store".into()));
+    }
+
+    #[test]
+    fn semantic_name_virtual_store() {
+        let path = PathBuf::from("/project/node_modules/.pnpm");
+        assert_eq!(semantic_name(&path), Some("pnpm Virtual Store".into()));
+    }
+
+    #[test]
+    fn semantic_name_store_version() {
+        let path = PathBuf::from("/home/user/.pnpm-store/v3");
+        assert_eq!(semantic_name(&path), Some("Store v3".into()));
+    }
+
+    #[test]
+    fn semantic_name_virtual_store_entry() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21");
+        assert_eq!(semantic_name(&path), Some("lodash 4.17.21".into()));
+    }
+
+    #[test]
+    fn semantic_name_virtual_store_scoped() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/@babel+core@7.24.0");
+        assert_eq!(semantic_name(&path), Some("@babel/core 7.24.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_content_files() {
+        let path = PathBuf::from("/home/user/.pnpm-store/v3/files");
+        assert_eq!(semantic_name(&path), Some("Content Files".into()));
+    }
+
+    // --- Package ID ---
+
+    #[test]
+    fn package_id_virtual_store_entry() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "lodash");
+        assert_eq!(id.version, "4.17.21");
+    }
+
+    #[test]
+    fn package_id_virtual_store_scoped() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/@babel+core@7.24.0");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "@babel/core");
+        assert_eq!(id.version, "7.24.0");
+    }
+
+    #[test]
+    fn package_id_content_store_returns_none() {
+        let path = PathBuf::from("/home/user/.pnpm-store/v3/files/ab/cd1234");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_pnpm_dir_returns_none() {
+        let path = PathBuf::from("/project/node_modules/.pnpm");
+        assert_eq!(package_id(&path), None);
+    }
+
+    // --- Metadata ---
+
+    #[test]
+    fn metadata_pnpm_store_shows_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_dir = tmp.path().join(".pnpm-store");
+        std::fs::create_dir_all(&store_dir).unwrap();
+        std::fs::create_dir_all(store_dir.join("v3")).unwrap();
+
+        let fields = metadata(&store_dir);
+        assert!(fields.iter().any(|f| f.label == "Entries"));
+    }
+
+    #[test]
+    fn metadata_virtual_store_entry_shows_type() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lodash@4.17.21");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Type" && f.value == "Virtual store entry")
+        );
+    }
+
+    #[test]
+    fn metadata_content_store_shows_type() {
+        let path = PathBuf::from("/home/user/.pnpm-store/v3/files/ab");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Type" && f.value == "Content-addressed store")
+        );
+    }
+}

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -102,6 +102,16 @@ pub fn semantic_name(path: &Path) -> Option<String> {
         if name == "files" {
             return Some("Content Files".to_string());
         }
+        if name == "index" {
+            return Some("Package Index".to_string());
+        }
+    }
+
+    // Index files: {hash}-name@version.json → "name version"
+    if name.ends_with(".json") && path_str.contains("/index/") {
+        if let Some(id) = parse_index_filename(&name) {
+            return Some(format!("{} {}", id.name, id.version));
+        }
     }
 
     // Virtual store entries: name@version directories
@@ -115,34 +125,73 @@ pub fn semantic_name(path: &Path) -> Option<String> {
 }
 
 pub fn package_id(path: &Path) -> Option<super::PackageId> {
-    // Only for virtual store entries
-    if !is_pnpm_virtual_store(path) {
-        return None;
-    }
-
     let name = path.file_name()?.to_string_lossy().to_string();
 
-    // Must contain '@' to be a name@version entry
-    if !name.contains('@') {
+    // pnpm v10 index files: {hash}-{name}@{version}.json
+    if name.ends_with(".json") {
+        let path_str = path.to_string_lossy();
+        if path_str.contains("/index/") {
+            return parse_index_filename(&name);
+        }
+    }
+
+    // Virtual store entries: name@version directories
+    if is_pnpm_virtual_store(path) && name.contains('@') {
+        let (pkg, ver) = parse_virtual_store_name(&name)?;
+        if ver.starts_with(|c: char| c.is_ascii_digit()) {
+            return Some(super::PackageId {
+                ecosystem: "npm",
+                name: pkg,
+                version: ver,
+            });
+        }
+    }
+
+    None
+}
+
+/// Parse a pnpm v10 index filename into a PackageId.
+///
+/// Format: `{62-hex-chars}-{name}@{version}.json`
+/// Scoped: `{62-hex-chars}-@{scope}+{name}@{version}.json`
+///
+/// The filename hash is 62 hex chars (the parent directory has the first 2,
+/// making 64 total = SHA-256).
+fn parse_index_filename(filename: &str) -> Option<super::PackageId> {
+    let base = filename.strip_suffix(".json")?;
+
+    // The hash is 62 hex chars, followed by '-', then the package spec.
+    // Validate and skip the hash prefix.
+    if base.len() < 64 {
+        return None; // too short: need 62 hash + '-' + at least 1 char
+    }
+    let hash_part = &base[..62];
+    if !hash_part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    if base.as_bytes()[62] != b'-' {
+        return None;
+    }
+    let spec = &base[63..]; // "name@version" or "@scope+name@version"
+
+    // Find the last '@' which separates name from version
+    let at_pos = spec.rfind('@')?;
+    let version = &spec[at_pos + 1..];
+    if version.is_empty() || !version.starts_with(|c: char| c.is_ascii_digit()) {
         return None;
     }
 
-    let (pkg, ver) = parse_virtual_store_name(&name)?;
-
-    // Version must start with a digit
-    if !ver
-        .chars()
-        .next()
-        .map(|c| c.is_ascii_digit())
-        .unwrap_or(false)
-    {
+    let raw_name = &spec[..at_pos];
+    if raw_name.is_empty() {
         return None;
     }
+
+    let name = raw_name.replace('+', "/");
 
     Some(super::PackageId {
         ecosystem: "npm",
-        name: pkg,
-        version: ver,
+        name,
+        version: version.to_string(),
     })
 }
 
@@ -327,6 +376,49 @@ mod tests {
     #[test]
     fn package_id_pnpm_dir_returns_none() {
         let path = PathBuf::from("/project/node_modules/.pnpm");
+        assert_eq!(package_id(&path), None);
+    }
+
+    // --- Index file parsing (pnpm v10) ---
+
+    #[test]
+    fn package_id_index_unscoped() {
+        let path = PathBuf::from(
+            "/Users/julien/Library/pnpm/store/v10/index/3e/585d15c8a594e20d7de57b362ea81754c011acb2641a19f1b72c8531ea3982-lodash@4.17.20.json",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "lodash");
+        assert_eq!(id.version, "4.17.20");
+    }
+
+    #[test]
+    fn package_id_index_scoped() {
+        let path = PathBuf::from(
+            "/Users/julien/Library/pnpm/store/v10/index/0e/0e8c6b62ac09d19bf960ba5290551491972f9f0c0c0ea8c8e35b8f217ffb9b-@babel+template@7.28.6.json",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "@babel/template");
+        assert_eq!(id.version, "7.28.6");
+    }
+
+    #[test]
+    fn package_id_index_hyphenated_name() {
+        let path = PathBuf::from(
+            "/home/user/.pnpm-store/v3/index/ab/985c96e984d46e95603f151dedf9c0568889ff824f2e522488b9fb7cb8a6c0-is-number-object@1.1.1.json",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "is-number-object");
+        assert_eq!(id.version, "1.1.1");
+    }
+
+    #[test]
+    fn package_id_index_content_files_still_none() {
+        let path = PathBuf::from(
+            "/Users/julien/Library/pnpm/store/v10/files/61/9a372bcd920fb462ca2d04d4440fa2",
+        );
         assert_eq!(package_id(&path), None);
     }
 

--- a/src/providers/pnpm.rs
+++ b/src/providers/pnpm.rs
@@ -410,4 +410,200 @@ mod tests {
         let path = PathBuf::from("/home/user/.pnpm-store/v3/foo@1.0.0");
         assert_eq!(semantic_name(&path), None);
     }
+
+    // =================================================================
+    // Adversarial tests — designed to break the parsers
+    // =================================================================
+
+    // --- parse_virtual_store_name: degenerate inputs ---
+
+    #[test]
+    fn parse_just_at_sign() {
+        assert_eq!(parse_virtual_store_name("@"), None);
+    }
+
+    #[test]
+    fn parse_empty_string() {
+        assert_eq!(parse_virtual_store_name(""), None);
+    }
+
+    #[test]
+    fn parse_at_at_end() {
+        // Name with @ at end — empty version
+        assert_eq!(parse_virtual_store_name("lodash@"), None);
+    }
+
+    #[test]
+    fn parse_multiple_at_signs() {
+        // Extra @ in the middle — rfind finds the last one
+        let result = parse_virtual_store_name("foo@bar@1.0.0");
+        assert_eq!(result, Some(("foo@bar".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn parse_scoped_trailing_slash() {
+        // @babel+@1.0.0 — after replace('+', '/'), name is "@babel/"
+        // This is an invalid package name but the parser accepts it
+        let result = parse_virtual_store_name("@babel+@1.0.0");
+        assert_eq!(result, Some(("@babel/".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn parse_underscores_in_name_no_peers() {
+        // Package with underscores but no peer deps
+        let result = parse_virtual_store_name("my_package@1.0.0");
+        assert_eq!(
+            result,
+            Some(("my_package".to_string(), "1.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_version_with_prerelease() {
+        let result = parse_virtual_store_name("typescript@5.0.0-beta.1");
+        assert_eq!(
+            result,
+            Some(("typescript".to_string(), "5.0.0-beta.1".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_version_with_build_metadata() {
+        let result = parse_virtual_store_name("pkg@1.0.0+build.123");
+        assert_eq!(
+            result,
+            Some(("pkg".to_string(), "1.0.0+build.123".to_string()))
+        );
+    }
+
+    // --- strip_peer_deps: adversarial ---
+
+    #[test]
+    fn strip_peers_no_at_sign() {
+        // No @ at all — return as-is
+        assert_eq!(strip_peer_deps("lodash"), "lodash");
+    }
+
+    #[test]
+    fn strip_peers_underscore_before_at() {
+        // Underscore in package name, before the version @
+        assert_eq!(strip_peer_deps("my_pkg@1.0.0"), "my_pkg@1.0.0");
+    }
+
+    #[test]
+    fn strip_peers_scoped_no_version() {
+        // Scoped package with no version @ — should return as-is
+        assert_eq!(strip_peer_deps("@scope+name"), "@scope+name");
+    }
+
+    #[test]
+    fn strip_peers_double_underscore() {
+        // Real pnpm output: double underscore seen in @testing-library/react peer chain
+        let result = strip_peer_deps(
+            "@testing-library+react@14.2.0_@types+react@18.3.28_react-dom@18.2.0_react@18.2.0__react@18.2.0",
+        );
+        assert_eq!(result, "@testing-library+react@14.2.0");
+    }
+
+    // --- package_id: adversarial ---
+
+    #[test]
+    fn package_id_lock_yaml_in_pnpm() {
+        // pnpm puts lock.yaml inside .pnpm — should not be parsed as a package
+        let path = PathBuf::from("/project/node_modules/.pnpm/lock.yaml");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_node_modules_dir_in_pnpm() {
+        // .pnpm/node_modules directory — not a package
+        let path = PathBuf::from("/project/node_modules/.pnpm/node_modules");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_version_zero() {
+        // Version starting with 0 — should be accepted
+        let path = PathBuf::from("/project/node_modules/.pnpm/pkg@0.0.1");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "pkg");
+        assert_eq!(id.version, "0.0.1");
+    }
+
+    #[test]
+    fn package_id_version_is_tag() {
+        // @next, @canary — not numeric, should be rejected
+        let path = PathBuf::from("/project/node_modules/.pnpm/pkg@next");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_version_is_canary() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/pkg@canary");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_scoped_with_complex_peers() {
+        // Real-world: scoped + multiple peer deps
+        let path = PathBuf::from(
+            "/project/node_modules/.pnpm/@testing-library+react@14.2.0_@types+react@18.3.28_react-dom@18.2.0_react@18.2.0__react@18.2.0",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "@testing-library/react");
+        assert_eq!(id.version, "14.2.0");
+        assert_eq!(id.ecosystem, "npm");
+    }
+
+    #[test]
+    fn package_id_not_in_virtual_store() {
+        // Has @ but is NOT under node_modules/.pnpm
+        let path = PathBuf::from("/home/user/.pnpm-store/v3/lodash@4.17.21");
+        assert_eq!(package_id(&path), None);
+    }
+
+    // --- semantic_name: adversarial ---
+
+    #[test]
+    fn semantic_name_lock_yaml() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/lock.yaml");
+        // No @ sign, so should not try to parse
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_node_modules_inside_pnpm() {
+        let path = PathBuf::from("/project/node_modules/.pnpm/node_modules");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_store_v4_not_recognized() {
+        // semantic_name only recognizes "v3" specifically — future versions
+        // would need a code update. This documents current behavior.
+        let path = PathBuf::from("/home/user/.pnpm-store/v4");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    // --- metadata: adversarial ---
+
+    #[test]
+    fn metadata_empty_vec_for_unknown_path() {
+        let path = PathBuf::from("/tmp/random/dir");
+        let fields = metadata(&path);
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn metadata_pnpm_store_shows_correct_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_dir = tmp.path().join(".pnpm-store");
+        std::fs::create_dir_all(store_dir.join("v3")).unwrap();
+        std::fs::create_dir_all(store_dir.join("tmp")).unwrap();
+        std::fs::write(store_dir.join("some-file"), "x").unwrap();
+
+        let fields = metadata(&store_dir);
+        let entries_field = fields.iter().find(|f| f.label == "Entries").unwrap();
+        assert_eq!(entries_field.value, "3"); // v3 + tmp + some-file
+    }
 }

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -39,23 +39,43 @@ pub fn normalize_scoped_name(name: &str) -> String {
 pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
     let stem = filename.strip_suffix(".zip")?;
 
-    // Find the `-npm-` marker
     let npm_marker = "-npm-";
-    let npm_pos = stem.find(npm_marker)?;
+
+    // Find the correct `-npm-` boundary. Package names can contain `-npm-`
+    // (e.g., `use-npm-module`), so we search from right to left for
+    // a `-npm-` that is followed by a valid version (digit-starting).
+    let mut search_from = stem.len();
+    let npm_pos = loop {
+        // rfind within stem[..search_from]
+        let slice = &stem[..search_from];
+        let pos = slice.rfind(npm_marker)?;
+        let after = &stem[pos + npm_marker.len()..];
+        // Check if what follows starts with a digit (version)
+        if after
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            break pos;
+        }
+        // Try earlier occurrence
+        if pos == 0 {
+            return None;
+        }
+        search_from = pos;
+    };
 
     let raw_name = &stem[..npm_pos];
     let after_npm = &stem[npm_pos + npm_marker.len()..];
 
     // after_npm = "<version>-<hash>"
-    // Split from right: last segment is hash, everything before last hyphen is version
-    // But version can contain hyphens (e.g. "5.0.0-beta.1"), so we need to find where
-    // the hash starts. Hashes are hex strings (8+ chars). Walk from right.
     let parts: Vec<&str> = after_npm.split('-').collect();
     if parts.len() < 2 {
         return None;
     }
 
-    // Last part should be the hash: all hex chars
+    // Last part should be the hash
     let hash = parts.last()?;
     if !is_hex_hash(hash) {
         return None;
@@ -65,7 +85,11 @@ pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
     let version_parts = &parts[..parts.len() - 1];
     let version = version_parts.join("-");
 
-    // Version must start with a digit
+    if version.is_empty() {
+        return None;
+    }
+
+    // Version must start with a digit (already guaranteed by the search above, but be safe)
     if !version
         .chars()
         .next()
@@ -141,7 +165,9 @@ pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
 
 /// Returns true if the string looks like a hex hash (8+ lowercase hex chars).
 fn is_hex_hash(s: &str) -> bool {
-    s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit())
+    s.len() >= 8
+        && s.chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
 }
 
 pub fn semantic_name(path: &Path) -> Option<String> {
@@ -441,6 +467,75 @@ mod tests {
     fn package_id_directory_returns_none() {
         let path = PathBuf::from("/project/.yarn/cache");
         assert_eq!(package_id(&path), None);
+    }
+
+    // --- Bug 1: package name contains "-npm-" ---
+
+    #[test]
+    fn parse_berry_package_name_contains_npm() {
+        // Package name contains "-npm-" substring
+        let result = parse_berry_filename("use-npm-module-npm-1.0.0-abcdef012345.zip");
+        assert_eq!(
+            result,
+            Some(("use-npm-module".to_string(), "1.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_berry_npm_run_all() {
+        // Real-world popular package with "npm" in name
+        let result = parse_berry_filename("npm-run-all-npm-4.1.5-abcdef012345.zip");
+        assert_eq!(
+            result,
+            Some(("npm-run-all".to_string(), "4.1.5".to_string()))
+        );
+    }
+
+    // --- Bug 3: is_hex_hash boundary tests ---
+
+    #[test]
+    fn hex_hash_rejects_7_chars() {
+        assert!(!is_hex_hash("abcdef0"));
+    }
+
+    #[test]
+    fn hex_hash_accepts_8_chars() {
+        assert!(is_hex_hash("abcdef01"));
+    }
+
+    #[test]
+    fn hex_hash_rejects_uppercase() {
+        assert!(!is_hex_hash("ABCDEF01"));
+    }
+
+    // --- Edge case tests ---
+
+    #[test]
+    fn parse_classic_digit_in_package_name() {
+        // Package name starts with or contains digits
+        let result = parse_classic_filename("npm-base64-js-1.5.1-abcdef012345.tgz");
+        assert_eq!(result, Some(("base64-js".to_string(), "1.5.1".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_2to3() {
+        let result = parse_classic_filename("npm-2to3-1.0.0-abcdef012345.tgz");
+        assert_eq!(result, Some(("2to3".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn normalize_scoped_multi_hyphen() {
+        // Scoped package with hyphens in package name
+        assert_eq!(
+            normalize_scoped_name("@babel-plugin-transform-runtime"),
+            "@babel/plugin-transform-runtime"
+        );
+    }
+
+    #[test]
+    fn semantic_name_berry_global_cache() {
+        let path = PathBuf::from("/home/user/.cache/yarn/berry/cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Berry Cache".into()));
     }
 
     // --- Metadata ---

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -20,6 +20,12 @@ pub fn is_berry(path: &Path) -> bool {
 
 /// Normalize a scoped package name: "@babel-core" → "@babel/core".
 /// Only the first hyphen after '@' becomes a '/'.
+///
+/// NOTE: This is a best-effort heuristic for Yarn filenames where `/` is replaced
+/// with `-`. It is WRONG for scopes that contain hyphens (e.g., `@eslint-community`
+/// becomes `@eslint/community-eslint-utils` instead of `@eslint-community/eslint-utils`).
+/// For Yarn Classic directories, we resolve this by reading node_modules/ inside the entry.
+/// For Yarn Berry zips, this limitation is accepted — the version and ecosystem are correct.
 pub fn normalize_scoped_name(name: &str) -> String {
     if let Some(rest) = name.strip_prefix('@') {
         if let Some(hyphen_pos) = rest.find('-') {
@@ -69,20 +75,28 @@ pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
     let raw_name = &stem[..npm_pos];
     let after_npm = &stem[npm_pos + npm_marker.len()..];
 
-    // after_npm = "<version>-<hash>"
+    // after_npm = "<version>-<hash>" or "<version>-<hash1>-<hash2>" (two hash segments)
     let parts: Vec<&str> = after_npm.split('-').collect();
     if parts.len() < 2 {
         return None;
     }
 
-    // Last part should be the hash
-    let hash = parts.last()?;
-    if !is_hex_hash(hash) {
-        return None;
+    // Berry uses two hash segments (e.g., "c076fd2279-3d1ce6ebc6").
+    // Strip ALL trailing hex hash segments from right.
+    let mut hash_start = parts.len();
+    for i in (0..parts.len()).rev() {
+        if is_hex_hash(parts[i]) {
+            hash_start = i;
+        } else {
+            break;
+        }
     }
 
-    // Everything before the hash is the version
-    let version_parts = &parts[..parts.len() - 1];
+    if hash_start >= parts.len() {
+        return None; // No hash found
+    }
+
+    let version_parts = &parts[..hash_start];
     let version = version_parts.join("-");
 
     if version.is_empty() {
@@ -176,6 +190,32 @@ pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
     Some((name, version))
 }
 
+/// For Classic cache entries that are directories, resolve the real scoped package
+/// name by reading the node_modules/ structure inside the entry.
+/// Returns the real scoped name (e.g., "@eslint-community/eslint-utils") if found.
+fn resolve_classic_scope(entry_path: &Path) -> Option<String> {
+    let nm = entry_path.join("node_modules");
+    if !nm.is_dir() {
+        return None;
+    }
+    // Look for a directory starting with @
+    let entries = std::fs::read_dir(&nm).ok()?;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('@') && entry.path().is_dir() {
+            // Found the scope dir — read the first package inside it
+            if let Some(sub) = std::fs::read_dir(entry.path())
+                .ok()
+                .and_then(|mut entries| entries.find_map(|e| e.ok()))
+            {
+                let pkg_name = sub.file_name().to_string_lossy().to_string();
+                return Some(format!("{name}/{pkg_name}"));
+            }
+        }
+    }
+    None
+}
+
 /// Returns true if the string looks like a hex hash (8+ lowercase hex chars).
 fn is_hex_hash(s: &str) -> bool {
     s.len() >= 8
@@ -209,7 +249,13 @@ pub fn semantic_name(path: &Path) -> Option<String> {
 
     // Classic entries: directories ending in -integrity or legacy .tgz files
     if name.ends_with("-integrity") || name.ends_with(".tgz") {
-        if let Some((pkg, ver)) = parse_classic_filename(&name) {
+        if let Some((mut pkg, ver)) = parse_classic_filename(&name) {
+            // For Classic directories, resolve scoped names from node_modules/
+            if pkg.starts_with('@') && path.is_dir() {
+                if let Some(real_name) = resolve_classic_scope(path) {
+                    pkg = real_name;
+                }
+            }
             return Some(format!("{} {}", pkg, ver));
         }
     }
@@ -231,7 +277,13 @@ pub fn package_id(path: &Path) -> Option<super::PackageId> {
 
     // Classic: directories ending in -integrity or legacy .tgz files
     if name.ends_with("-integrity") || name.ends_with(".tgz") {
-        let (pkg, ver) = parse_classic_filename(&name)?;
+        let (mut pkg, ver) = parse_classic_filename(&name)?;
+        // For Classic directories, resolve scoped names from node_modules/
+        if pkg.starts_with('@') && path.is_dir() {
+            if let Some(real_name) = resolve_classic_scope(path) {
+                pkg = real_name;
+            }
+        }
         return Some(super::PackageId {
             ecosystem: "npm",
             name: pkg,
@@ -649,6 +701,89 @@ mod tests {
                 .iter()
                 .any(|f| f.label == "Format" && f.value.contains("Classic"))
         );
+    }
+
+    // --- Real-world filenames from disk ---
+
+    #[test]
+    fn parse_berry_two_segment_hash() {
+        // Real Berry filename with two 10-char hash segments
+        let result =
+            parse_berry_filename("@jridgewell-trace-mapping-npm-0.3.25-c076fd2279-3d1ce6ebc6.zip");
+        assert_eq!(
+            result,
+            Some((
+                "@jridgewell/trace-mapping".to_string(),
+                "0.3.25".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_berry_eslint_community_two_hashes() {
+        let result = parse_berry_filename(
+            "@eslint-community-eslint-utils-npm-4.4.0-d1791bd5a3-7e559c4ce5.zip",
+        );
+        // NOTE: scope is wrong (@eslint instead of @eslint-community) — known limitation
+        let (name, ver) = result.unwrap();
+        assert_eq!(ver, "4.4.0"); // Version must be correct
+        assert!(name.starts_with('@')); // Must be scoped
+        assert!(name.contains("eslint")); // Contains the right words
+    }
+
+    #[test]
+    fn parse_classic_integrity_resolved_scope() {
+        // Create a real Classic entry with node_modules inside
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp.path().join(
+            "npm-@eslint-community-eslint-utils-4.4.0-a23514e8fb9af1269d5f7788aa556798d61c6b59-integrity",
+        );
+        std::fs::create_dir_all(entry.join("node_modules/@eslint-community/eslint-utils")).unwrap();
+
+        let id = package_id(&entry).unwrap();
+        assert_eq!(id.name, "@eslint-community/eslint-utils"); // Must be correct!
+        assert_eq!(id.version, "4.4.0");
+        assert_eq!(id.ecosystem, "npm");
+    }
+
+    #[test]
+    fn semantic_name_classic_integrity_resolved_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp.path().join(
+            "npm-@eslint-community-eslint-utils-4.4.0-a23514e8fb9af1269d5f7788aa556798d61c6b59-integrity",
+        );
+        std::fs::create_dir_all(entry.join("node_modules/@eslint-community/eslint-utils")).unwrap();
+
+        assert_eq!(
+            semantic_name(&entry),
+            Some("@eslint-community/eslint-utils 4.4.0".into())
+        );
+    }
+
+    #[test]
+    fn parse_berry_ampproject() {
+        let result =
+            parse_berry_filename("@ampproject-remapping-npm-2.3.0-ed441b6fa6-7e559c4ce5.zip");
+        assert_eq!(
+            result,
+            Some(("@ampproject/remapping".to_string(), "2.3.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_classic_scope_no_node_modules() {
+        // Entry without node_modules — fallback to heuristic
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = tmp
+            .path()
+            .join("npm-@babel-core-7.24.0-abc123def456abcdef0123456789abcdef01234567-integrity");
+        std::fs::create_dir_all(&entry).unwrap();
+        // No node_modules inside
+
+        // package_id should still work, falling back to heuristic
+        let id = package_id(&entry).unwrap();
+        assert_eq!(id.name, "@babel/core"); // Heuristic (happens to be correct for @babel)
+        assert_eq!(id.version, "7.24.0");
     }
 
     #[test]

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -841,4 +841,291 @@ mod tests {
         assert!(pkg_field.is_some(), "Expected Packages field");
         assert_eq!(pkg_field.unwrap().value, "3");
     }
+
+    // =================================================================
+    // Adversarial tests — designed to break the parsers
+    // =================================================================
+
+    // --- Berry: malformed and degenerate inputs ---
+
+    #[test]
+    fn berry_empty_zip() {
+        assert_eq!(parse_berry_filename(".zip"), None);
+    }
+
+    #[test]
+    fn berry_no_version_only_hash() {
+        // Has -npm- but nothing valid after it
+        assert_eq!(parse_berry_filename("lodash-npm-abcdef012345.zip"), None);
+    }
+
+    #[test]
+    fn berry_hash_too_short() {
+        // Hash is only 7 chars — should fail is_hex_hash
+        assert_eq!(parse_berry_filename("lodash-npm-4.17.21-abcdef0.zip"), None);
+    }
+
+    #[test]
+    fn berry_no_hash_at_all() {
+        // Version but no hash segment
+        assert_eq!(parse_berry_filename("lodash-npm-4.17.21.zip"), None);
+    }
+
+    #[test]
+    fn berry_not_a_zip() {
+        assert_eq!(
+            parse_berry_filename("lodash-npm-4.17.21-abcdef012345.tar.gz"),
+            None
+        );
+    }
+
+    #[test]
+    fn berry_empty_name_before_npm() {
+        // "-npm-" at the very start: no package name
+        let result = parse_berry_filename("-npm-1.0.0-abcdef012345.zip");
+        // raw_name would be "", normalize_scoped_name returns ""
+        // This should parse as name="" which is questionable but let's document behavior
+        assert!(
+            result.is_none() || result.as_ref().unwrap().0.is_empty(),
+            "Empty name should either be None or empty: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn berry_three_hash_segments() {
+        // Some Berry versions may produce three hash segments
+        let result =
+            parse_berry_filename("lodash-npm-4.17.21-abcdef0123-bcdef01234-cdef012345.zip");
+        assert_eq!(result, Some(("lodash".to_string(), "4.17.21".to_string())));
+    }
+
+    #[test]
+    fn berry_version_with_build_metadata() {
+        // semver build metadata uses +, which becomes a hyphen in filenames?
+        // Actually + is not valid in filenames typically. Test the unlikely case.
+        let result = parse_berry_filename("pkg-npm-1.0.0-abcdef012345.zip");
+        assert_eq!(result, Some(("pkg".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn berry_dots_in_package_name() {
+        // socket.io has dots in the name — Yarn may or may not encode these
+        let result = parse_berry_filename("socket.io-npm-4.7.5-abcdef012345.zip");
+        assert_eq!(result, Some(("socket.io".to_string(), "4.7.5".to_string())));
+    }
+
+    #[test]
+    fn berry_very_long_package_name() {
+        let result = parse_berry_filename(
+            "@anthropic-ai-very-long-package-name-with-many-hyphens-npm-1.0.0-abcdef012345.zip",
+        );
+        let (name, ver) = result.unwrap();
+        assert_eq!(ver, "1.0.0");
+        assert!(name.starts_with('@'));
+    }
+
+    #[test]
+    fn berry_prerelease_that_looks_like_hash() {
+        // Pre-release segment "0deadbeef0" is all hex and 10 chars — could be confused for hash
+        let result = parse_berry_filename("pkg-npm-2.0.0-0deadbeef0-abc123def456.zip");
+        // "0deadbeef0" is 10 hex chars — it will be treated as first hash segment
+        // So version becomes "2.0.0" which is correct (the pre-release IS the hash)
+        // This is actually fine — Yarn wouldn't produce this ambiguity since
+        // pre-release is part of the version in the -npm- marker
+        let (_, ver) = result.unwrap();
+        assert_eq!(ver, "2.0.0");
+    }
+
+    // --- Classic: malformed and degenerate inputs ---
+
+    #[test]
+    fn classic_empty_integrity() {
+        assert_eq!(parse_classic_filename("-integrity"), None);
+    }
+
+    #[test]
+    fn classic_npm_prefix_only() {
+        assert_eq!(parse_classic_filename("npm--integrity"), None);
+    }
+
+    #[test]
+    fn classic_no_version_segment() {
+        // Name parts only, no digit-with-dot segment
+        assert_eq!(
+            parse_classic_filename("npm-lodash-abcdef012345-integrity"),
+            None
+        );
+    }
+
+    #[test]
+    fn classic_hash_is_not_hex() {
+        // Hash contains non-hex characters
+        assert_eq!(
+            parse_classic_filename("npm-lodash-4.17.21-zzzzzzzzzzzz-integrity"),
+            None
+        );
+    }
+
+    #[test]
+    fn classic_too_few_parts() {
+        // Only name and hash, no version
+        assert_eq!(parse_classic_filename("npm-abcdef012345-integrity"), None);
+    }
+
+    #[test]
+    fn classic_dots_in_package_name() {
+        // socket.io — the dot is in a "name" segment, not a version segment
+        let result = parse_classic_filename(
+            "npm-socket.io-4.7.5-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        assert_eq!(result, Some(("socket.io".to_string(), "4.7.5".to_string())));
+    }
+
+    #[test]
+    fn classic_es5_ext() {
+        // es5-ext has "5" in the name which starts with a digit but has no dot
+        let result = parse_classic_filename(
+            "npm-es5-ext-0.10.62-5e6f21a5eb74a30d4a86967fad5c1953e9d28e91-integrity",
+        );
+        assert_eq!(result, Some(("es5-ext".to_string(), "0.10.62".to_string())));
+    }
+
+    #[test]
+    fn classic_level_6_lru_cache() {
+        // Package name has "6" embedded — should not be confused for version
+        let result = parse_classic_filename(
+            "npm-level-6-lru-cache-1.0.0-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        assert_eq!(
+            result,
+            Some(("level-6-lru-cache".to_string(), "1.0.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn classic_version_0x() {
+        // Version starting with 0 (0.x.y) — common for pre-1.0 packages
+        let result = parse_classic_filename(
+            "npm-some-pkg-0.1.0-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        assert_eq!(result, Some(("some-pkg".to_string(), "0.1.0".to_string())));
+    }
+
+    #[test]
+    fn classic_calendar_version_prerelease() {
+        // Version like 1.0.0-20240101 — digit-starting pre-release with no dot
+        let result = parse_classic_filename(
+            "npm-my-tool-1.0.0-20240101-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        // "20240101" has no dot and is 8 chars of digits — but it's NOT all hex
+        // (contains no a-f). Wait, it IS valid hex since 0-9 are hex digits.
+        // is_hex_hash("20240101") → true (8 digits, all valid hex). So
+        // "20240101" would be treated as the hash, not a pre-release tag!
+        // The REAL hash "abcdef012345..." comes after. Let me re-trace:
+        // parts after stripping "npm-" and "-integrity":
+        //   ["my", "tool", "1.0.0", "20240101", "abcdef012345abcdef012345abcdef012345abcd"]
+        // Last part: "abcdef012345abcdef012345abcdef012345abcd" (40 chars, all hex) → hash ✓
+        // without_hash: ["my", "tool", "1.0.0", "20240101"]
+        // Walk forward looking for digit+dot: i=2 "1.0.0" → version_start=2
+        // name = "my-tool", version = "1.0.0-20240101" ✓
+        assert_eq!(
+            result,
+            Some(("my-tool".to_string(), "1.0.0-20240101".to_string()))
+        );
+    }
+
+    // --- is_hex_hash boundary tests ---
+
+    #[test]
+    fn hex_hash_all_digits() {
+        // Pure digits can be valid hex — this is a design choice
+        assert!(is_hex_hash("12345678"));
+    }
+
+    #[test]
+    fn hex_hash_empty() {
+        assert!(!is_hex_hash(""));
+    }
+
+    #[test]
+    fn hex_hash_mixed_case_rejected() {
+        assert!(!is_hex_hash("abcdEF01"));
+    }
+
+    #[test]
+    fn hex_hash_with_g_rejected() {
+        assert!(!is_hex_hash("abcdefg1"));
+    }
+
+    // --- normalize_scoped_name edge cases ---
+
+    #[test]
+    fn normalize_at_with_no_hyphen() {
+        // "@scope" with no hyphen — returned as-is
+        assert_eq!(normalize_scoped_name("@scope"), "@scope");
+    }
+
+    #[test]
+    fn normalize_empty_string() {
+        assert_eq!(normalize_scoped_name(""), "");
+    }
+
+    #[test]
+    fn normalize_bare_at() {
+        assert_eq!(normalize_scoped_name("@"), "@");
+    }
+
+    #[test]
+    fn normalize_at_hyphen_only() {
+        // "@-rest" — scope is empty, package is "rest"
+        assert_eq!(normalize_scoped_name("@-rest"), "@/rest");
+    }
+
+    // --- metadata fallthrough paths ---
+
+    #[test]
+    fn metadata_yarn_non_package_file_returns_empty() {
+        let path = PathBuf::from("/project/.yarn/cache/README.md");
+        let fields = metadata(&path);
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn metadata_yarn_empty_cache_dir_returns_no_packages_field() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        // No zip or integrity entries — just a random file
+        std::fs::write(cache_dir.join("README.md"), "x").unwrap();
+
+        let fields = metadata(&cache_dir);
+        let pkg_field = fields.iter().find(|f| f.label == "Packages");
+        assert!(
+            pkg_field.is_none(),
+            "Should not show Packages field when count is 0"
+        );
+    }
+
+    // --- package_id: verify ALL fields, not just name ---
+
+    #[test]
+    fn package_id_berry_verifies_all_fields() {
+        let path = PathBuf::from("/project/.yarn/cache/@types-node-npm-22.0.0-abc123def456.zip");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "@types/node");
+        assert_eq!(id.version, "22.0.0");
+    }
+
+    #[test]
+    fn package_id_classic_integrity_verifies_all_fields() {
+        let path = PathBuf::from(
+            "/home/user/Library/Caches/Yarn/v6/npm-express-4.21.0-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "express");
+        assert_eq!(id.version, "4.21.0");
+    }
 }

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -1,0 +1,494 @@
+use super::MetadataField;
+use std::path::Path;
+
+/// Returns true if the path is within a known Yarn cache location.
+#[allow(dead_code)]
+pub fn is_yarn_cache(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains(".yarn-cache")
+        || path_str.contains(".cache/yarn")
+        || path_str.contains("Library/Caches/Yarn")
+        || path_str.contains(".yarn/cache")
+        || path_str.contains("yarn/berry/cache")
+}
+
+/// Returns true if this is a Yarn Berry (v2+) cache path.
+#[allow(dead_code)]
+pub fn is_berry(path: &Path) -> bool {
+    let path_str = path.to_string_lossy();
+    path_str.contains(".yarn/cache") || path_str.contains("berry/cache")
+}
+
+/// Normalize a scoped package name: "@babel-core" → "@babel/core".
+/// Only the first hyphen after '@' becomes a '/'.
+#[allow(dead_code)]
+pub fn normalize_scoped_name(name: &str) -> String {
+    if let Some(rest) = name.strip_prefix('@') {
+        if let Some(hyphen_pos) = rest.find('-') {
+            let scope = &rest[..hyphen_pos];
+            let pkg = &rest[hyphen_pos + 1..];
+            return format!("@{}/{}", scope, pkg);
+        }
+    }
+    name.to_string()
+}
+
+/// Parse a Yarn Berry filename: `<name>-npm-<version>-<hash>.zip`
+///
+/// Examples:
+/// - `lodash-npm-4.17.21-6382d821f21d.zip` → `("lodash", "4.17.21")`
+/// - `@babel-core-npm-7.24.0-abc123def456.zip` → `("@babel/core", "7.24.0")`
+#[allow(dead_code)]
+pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
+    let stem = filename.strip_suffix(".zip")?;
+
+    // Find the `-npm-` marker
+    let npm_marker = "-npm-";
+    let npm_pos = stem.find(npm_marker)?;
+
+    let raw_name = &stem[..npm_pos];
+    let after_npm = &stem[npm_pos + npm_marker.len()..];
+
+    // after_npm = "<version>-<hash>"
+    // Split from right: last segment is hash, everything before last hyphen is version
+    // But version can contain hyphens (e.g. "5.0.0-beta.1"), so we need to find where
+    // the hash starts. Hashes are hex strings (8+ chars). Walk from right.
+    let parts: Vec<&str> = after_npm.split('-').collect();
+    if parts.len() < 2 {
+        return None;
+    }
+
+    // Last part should be the hash: all hex chars
+    let hash = parts.last()?;
+    if !is_hex_hash(hash) {
+        return None;
+    }
+
+    // Everything before the hash is the version
+    let version_parts = &parts[..parts.len() - 1];
+    let version = version_parts.join("-");
+
+    // Version must start with a digit
+    if !version
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let name = normalize_scoped_name(raw_name);
+    Some((name, version))
+}
+
+/// Parse a Yarn Classic filename: `npm-<name>-<version>-<hash>.tgz`
+///
+/// Examples:
+/// - `npm-lodash-4.17.21-6382d821f21d.tgz` → `("lodash", "4.17.21")`
+/// - `npm-@babel-core-7.24.0-abc123def456.tgz` → `("@babel/core", "7.24.0")`
+/// - `npm-is-even-1.0.0-abc123def456.tgz` → `("is-even", "1.0.0")`
+#[allow(dead_code)]
+pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
+    let stem = filename.strip_suffix(".tgz")?;
+
+    // Must start with "npm-"
+    let after_npm = stem.strip_prefix("npm-")?;
+
+    // after_npm = "<name>-<version>-<hash>"
+    // Split on '-' and walk from right to find hash, then version, then name
+    let parts: Vec<&str> = after_npm.split('-').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    // Last part is hash
+    let hash = parts.last()?;
+    if !is_hex_hash(hash) {
+        return None;
+    }
+
+    // Find version boundary: walk backwards from (len-2) to find the first
+    // segment that starts with a digit — that is the start of the version
+    let without_hash = &parts[..parts.len() - 1];
+
+    // Find the rightmost index where a digit-starting segment exists
+    // that, together with subsequent segments (before hash), forms a valid version
+    let mut version_start = None;
+    for i in (0..without_hash.len()).rev() {
+        if without_hash[i]
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+        {
+            version_start = Some(i);
+            break;
+        }
+    }
+
+    let ver_idx = version_start?;
+    if ver_idx == 0 {
+        // No name before the version
+        return None;
+    }
+
+    let name_parts = &without_hash[..ver_idx];
+    let version_parts = &without_hash[ver_idx..];
+
+    let raw_name = name_parts.join("-");
+    let version = version_parts.join("-");
+
+    let name = normalize_scoped_name(&raw_name);
+    Some((name, version))
+}
+
+/// Returns true if the string looks like a hex hash (8+ lowercase hex chars).
+fn is_hex_hash(s: &str) -> bool {
+    s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+#[allow(dead_code)]
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Cache root directory
+    if name == "cache" {
+        if is_berry(path) {
+            return Some("Yarn Berry Cache".to_string());
+        } else {
+            return Some("Yarn Cache".to_string());
+        }
+    }
+
+    // .yarn-cache directory
+    if name == ".yarn-cache" {
+        return Some("Yarn Classic Cache".to_string());
+    }
+
+    // Berry zip files
+    if name.ends_with(".zip") {
+        if let Some((pkg, ver)) = parse_berry_filename(&name) {
+            return Some(format!("{} {}", pkg, ver));
+        }
+    }
+
+    // Classic tgz files
+    if name.ends_with(".tgz") {
+        if let Some((pkg, ver)) = parse_classic_filename(&name) {
+            return Some(format!("{} {}", pkg, ver));
+        }
+    }
+
+    None
+}
+
+#[allow(dead_code)]
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    if name.ends_with(".zip") {
+        let (pkg, ver) = parse_berry_filename(&name)?;
+        return Some(super::PackageId {
+            ecosystem: "npm",
+            name: pkg,
+            version: ver,
+        });
+    }
+
+    if name.ends_with(".tgz") {
+        let (pkg, ver) = parse_classic_filename(&name)?;
+        return Some(super::PackageId {
+            ecosystem: "npm",
+            name: pkg,
+            version: ver,
+        });
+    }
+
+    None
+}
+
+#[allow(dead_code)]
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if name.ends_with(".zip") {
+        fields.push(MetadataField {
+            label: "Format".to_string(),
+            value: "Yarn Berry (.zip)".to_string(),
+        });
+        return fields;
+    }
+
+    if name.ends_with(".tgz") {
+        fields.push(MetadataField {
+            label: "Format".to_string(),
+            value: "Yarn Classic (.tgz)".to_string(),
+        });
+        return fields;
+    }
+
+    // Cache root directories: count .zip/.tgz files
+    if path.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(path) {
+            let count = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    let p = e.path();
+                    let ext = p
+                        .extension()
+                        .map(|x| x.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    ext == "zip" || ext == "tgz"
+                })
+                .count();
+            if count > 0 {
+                fields.push(MetadataField {
+                    label: "Packages".to_string(),
+                    value: count.to_string(),
+                });
+            }
+        }
+    }
+
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- Detection ---
+
+    #[test]
+    fn detects_classic_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from("/home/user/.yarn-cache/v6")));
+    }
+
+    #[test]
+    fn detects_classic_xdg_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from("/home/user/.cache/yarn/v6")));
+    }
+
+    #[test]
+    fn detects_berry_per_project_cache() {
+        assert!(is_yarn_cache(&PathBuf::from(
+            "/home/user/project/.yarn/cache"
+        )));
+    }
+
+    #[test]
+    fn detects_macos_yarn_cache() {
+        assert!(is_yarn_cache(&PathBuf::from(
+            "/Users/user/Library/Caches/Yarn/v6"
+        )));
+    }
+
+    #[test]
+    fn does_not_detect_unrelated_path() {
+        assert!(!is_yarn_cache(&PathBuf::from("/home/user/.npm/_cacache")));
+    }
+
+    // --- Berry parsing ---
+
+    #[test]
+    fn parse_berry_simple_package() {
+        let result = parse_berry_filename("lodash-npm-4.17.21-6382d821f21d.zip");
+        assert_eq!(result, Some(("lodash".to_string(), "4.17.21".to_string())));
+    }
+
+    #[test]
+    fn parse_berry_scoped_package() {
+        let result = parse_berry_filename("@babel-core-npm-7.24.0-abc123def456.zip");
+        assert_eq!(
+            result,
+            Some(("@babel/core".to_string(), "7.24.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_berry_prerelease_version() {
+        let result = parse_berry_filename("typescript-npm-5.0.0-beta.1-abcdef012345.zip");
+        assert_eq!(
+            result,
+            Some(("typescript".to_string(), "5.0.0-beta.1".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_berry_invalid_no_npm_marker() {
+        let result = parse_berry_filename("lodash-4.17.21-6382d821f21d.zip");
+        assert_eq!(result, None);
+    }
+
+    // --- Classic parsing ---
+
+    #[test]
+    fn parse_classic_simple_package() {
+        let result = parse_classic_filename("npm-lodash-4.17.21-6382d821f21d.tgz");
+        assert_eq!(result, Some(("lodash".to_string(), "4.17.21".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_scoped_package() {
+        let result = parse_classic_filename("npm-@babel-core-7.24.0-abc123def456.tgz");
+        assert_eq!(
+            result,
+            Some(("@babel/core".to_string(), "7.24.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_classic_hyphenated_name() {
+        let result = parse_classic_filename("npm-is-even-1.0.0-abc123def456.tgz");
+        assert_eq!(result, Some(("is-even".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_invalid_no_npm_prefix() {
+        let result = parse_classic_filename("lodash-4.17.21-6382d821f21d.tgz");
+        assert_eq!(result, None);
+    }
+
+    // --- Semantic name ---
+
+    #[test]
+    fn semantic_name_berry_zip() {
+        let path = PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-6382d821f21d.zip");
+        assert_eq!(semantic_name(&path), Some("lodash 4.17.21".into()));
+    }
+
+    #[test]
+    fn semantic_name_classic_tgz() {
+        let path = PathBuf::from("/home/user/.yarn-cache/v6/npm-express-4.21.0-abc123def456.tgz");
+        assert_eq!(semantic_name(&path), Some("express 4.21.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_cache_dir_berry() {
+        let path = PathBuf::from("/project/.yarn/cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Berry Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_cache_dir_classic() {
+        // .cache/yarn/cache is not a berry path
+        let path = PathBuf::from("/home/user/.cache/yarn/cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_yarn_cache_dir() {
+        let path = PathBuf::from("/home/user/.yarn-cache");
+        assert_eq!(semantic_name(&path), Some("Yarn Classic Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_unknown_file() {
+        let path = PathBuf::from("/home/user/.yarn/cache/README.md");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    // --- Normalize ---
+
+    #[test]
+    fn normalize_scoped() {
+        assert_eq!(normalize_scoped_name("@babel-core"), "@babel/core");
+    }
+
+    #[test]
+    fn normalize_unscoped() {
+        assert_eq!(normalize_scoped_name("lodash"), "lodash");
+    }
+
+    #[test]
+    fn normalize_scoped_deep() {
+        assert_eq!(normalize_scoped_name("@types-node"), "@types/node");
+    }
+
+    // --- Package ID ---
+
+    #[test]
+    fn package_id_berry_zip() {
+        let path = PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-6382d821f21d.zip");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "lodash");
+        assert_eq!(id.version, "4.17.21");
+    }
+
+    #[test]
+    fn package_id_classic_tgz() {
+        let path = PathBuf::from("/home/user/.cache/yarn/v6/npm-express-4.21.0-abc123def456.tgz");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "express");
+        assert_eq!(id.version, "4.21.0");
+    }
+
+    #[test]
+    fn package_id_scoped_berry() {
+        let path = PathBuf::from("/project/.yarn/cache/@babel-core-npm-7.24.0-abc123def456.zip");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "@babel/core");
+    }
+
+    #[test]
+    fn package_id_non_package_file() {
+        let path = PathBuf::from("/project/.yarn/cache/.gitignore");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_directory_returns_none() {
+        let path = PathBuf::from("/project/.yarn/cache");
+        assert_eq!(package_id(&path), None);
+    }
+
+    // --- Metadata ---
+
+    #[test]
+    fn metadata_berry_zip_shows_format() {
+        let path = PathBuf::from("/project/.yarn/cache/lodash-npm-4.17.21-6382d821f21d.zip");
+        let fields = metadata(&path);
+        assert!(!fields.is_empty());
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Format" && f.value.contains("Berry"))
+        );
+    }
+
+    #[test]
+    fn metadata_classic_tgz_shows_format() {
+        let path = PathBuf::from("/home/user/.cache/yarn/v6/npm-lodash-4.17.21-abc123def456.tgz");
+        let fields = metadata(&path);
+        assert!(!fields.is_empty());
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Format" && f.value.contains("Classic"))
+        );
+    }
+
+    #[test]
+    fn metadata_cache_dir_counts_packages() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(cache_dir.join("lodash-npm-4.17.21-abc123def456.zip"), "x").unwrap();
+        std::fs::write(cache_dir.join("express-npm-4.21.0-def789abc012.zip"), "x").unwrap();
+        std::fs::write(cache_dir.join("npm-lodash-4.17.21-abc123def456.tgz"), "x").unwrap();
+        std::fs::write(cache_dir.join("README.md"), "x").unwrap();
+
+        let fields = metadata(&cache_dir);
+        let pkg_field = fields.iter().find(|f| f.label == "Packages");
+        assert!(pkg_field.is_some(), "Expected Packages field");
+        assert_eq!(pkg_field.unwrap().value, "3");
+    }
+}

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -159,15 +159,22 @@ pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
     // segment that starts with a digit — that is the start of the version
     let without_hash = &parts[..parts.len() - 1];
 
-    // Find the rightmost index where a digit-starting segment exists
-    // that, together with subsequent segments (before hash), forms a valid version
+    // Find the leftmost digit-starting segment that contains at least one dot.
+    // This is the real semver version start (e.g., "1.0.0", "0.10.62").
+    // Everything after it (until the hash) is the full version string, including
+    // pre-release suffixes like "2024.1" or "3rc1".
+    // Pre-release-only tags like "2024" or "3beta" don't contain dots, so walking
+    // forward we find the first dotted digit segment as the true version start.
     let mut version_start = None;
-    for i in (0..without_hash.len()).rev() {
-        if without_hash[i]
+    for (i, seg) in without_hash.iter().enumerate() {
+        // Version segments contain dots (e.g., "1.0.0", "0.10.62")
+        // Pre-release tags like "2024" or "3beta" don't contain dots
+        if seg
             .chars()
             .next()
             .map(|c| c.is_ascii_digit())
             .unwrap_or(false)
+            && seg.contains('.')
         {
             version_start = Some(i);
             break;
@@ -784,6 +791,32 @@ mod tests {
         let id = package_id(&entry).unwrap();
         assert_eq!(id.name, "@babel/core"); // Heuristic (happens to be correct for @babel)
         assert_eq!(id.version, "7.24.0");
+    }
+
+    // --- Issue 2: pre-release digit-starting segments ---
+
+    #[test]
+    fn parse_classic_prerelease_digit_start() {
+        // Pre-release segment starting with digit but containing a dot should be
+        // included in the version, not treated as the version start
+        let result = parse_classic_filename(
+            "npm-some-pkg-1.0.0-2024.1-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        assert_eq!(
+            result,
+            Some(("some-pkg".to_string(), "1.0.0-2024.1".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_classic_prerelease_3rc1() {
+        let result = parse_classic_filename(
+            "npm-typescript-5.0.0-3rc1-abcdef012345abcdef012345abcdef012345abcd-integrity",
+        );
+        assert_eq!(
+            result,
+            Some(("typescript".to_string(), "5.0.0-3rc1".to_string()))
+        );
     }
 
     #[test]

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -13,7 +13,6 @@ pub fn is_yarn_cache(path: &Path) -> bool {
 }
 
 /// Returns true if this is a Yarn Berry (v2+) cache path.
-#[allow(dead_code)]
 pub fn is_berry(path: &Path) -> bool {
     let path_str = path.to_string_lossy();
     path_str.contains(".yarn/cache") || path_str.contains("berry/cache")
@@ -21,7 +20,6 @@ pub fn is_berry(path: &Path) -> bool {
 
 /// Normalize a scoped package name: "@babel-core" → "@babel/core".
 /// Only the first hyphen after '@' becomes a '/'.
-#[allow(dead_code)]
 pub fn normalize_scoped_name(name: &str) -> String {
     if let Some(rest) = name.strip_prefix('@') {
         if let Some(hyphen_pos) = rest.find('-') {
@@ -38,7 +36,6 @@ pub fn normalize_scoped_name(name: &str) -> String {
 /// Examples:
 /// - `lodash-npm-4.17.21-6382d821f21d.zip` → `("lodash", "4.17.21")`
 /// - `@babel-core-npm-7.24.0-abc123def456.zip` → `("@babel/core", "7.24.0")`
-#[allow(dead_code)]
 pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
     let stem = filename.strip_suffix(".zip")?;
 
@@ -88,7 +85,6 @@ pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
 /// - `npm-lodash-4.17.21-6382d821f21d.tgz` → `("lodash", "4.17.21")`
 /// - `npm-@babel-core-7.24.0-abc123def456.tgz` → `("@babel/core", "7.24.0")`
 /// - `npm-is-even-1.0.0-abc123def456.tgz` → `("is-even", "1.0.0")`
-#[allow(dead_code)]
 pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
     let stem = filename.strip_suffix(".tgz")?;
 
@@ -148,7 +144,6 @@ fn is_hex_hash(s: &str) -> bool {
     s.len() >= 8 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-#[allow(dead_code)]
 pub fn semantic_name(path: &Path) -> Option<String> {
     let name = path.file_name()?.to_string_lossy().to_string();
 
@@ -183,7 +178,6 @@ pub fn semantic_name(path: &Path) -> Option<String> {
     None
 }
 
-#[allow(dead_code)]
 pub fn package_id(path: &Path) -> Option<super::PackageId> {
     let name = path.file_name()?.to_string_lossy().to_string();
 
@@ -208,7 +202,6 @@ pub fn package_id(path: &Path) -> Option<super::PackageId> {
     None
 }
 
-#[allow(dead_code)]
 pub fn metadata(path: &Path) -> Vec<MetadataField> {
     let mut fields = Vec::new();
     let name = path

--- a/src/providers/yarn.rs
+++ b/src/providers/yarn.rs
@@ -103,14 +103,27 @@ pub fn parse_berry_filename(filename: &str) -> Option<(String, String)> {
     Some((name, version))
 }
 
-/// Parse a Yarn Classic filename: `npm-<name>-<version>-<hash>.tgz`
+/// Parse a Yarn Classic cache entry name.
+///
+/// Yarn Classic uses directories (not files) named:
+///   `npm-<name>-<version>-<hash>-integrity`
+/// Or legacy `.tgz` files:
+///   `npm-<name>-<version>-<hash>.tgz`
 ///
 /// Examples:
-/// - `npm-lodash-4.17.21-6382d821f21d.tgz` → `("lodash", "4.17.21")`
-/// - `npm-@babel-core-7.24.0-abc123def456.tgz` → `("@babel/core", "7.24.0")`
-/// - `npm-is-even-1.0.0-abc123def456.tgz` → `("is-even", "1.0.0")`
+/// - `npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity` → `("lodash", "4.17.21")`
+/// - `npm-@babel-core-7.24.0-56cbda6b185ae9d9bed369816a8f4423c5f2ff1b-integrity` → `("@babel/core", "7.24.0")`
+/// - `npm-is-even-1.0.0-76b5055fbad8d294a86b6a949015e1c97b717c06-integrity` → `("is-even", "1.0.0")`
+/// - `npm-lodash-4.17.21-6382d821f21d.tgz` → `("lodash", "4.17.21")` (legacy)
 pub fn parse_classic_filename(filename: &str) -> Option<(String, String)> {
-    let stem = filename.strip_suffix(".tgz")?;
+    // Strip known suffixes: "-integrity" (current format) or ".tgz" (legacy)
+    let stem = if let Some(s) = filename.strip_suffix("-integrity") {
+        s
+    } else if let Some(s) = filename.strip_suffix(".tgz") {
+        s
+    } else {
+        return None;
+    };
 
     // Must start with "npm-"
     let after_npm = stem.strip_prefix("npm-")?;
@@ -194,8 +207,8 @@ pub fn semantic_name(path: &Path) -> Option<String> {
         }
     }
 
-    // Classic tgz files
-    if name.ends_with(".tgz") {
+    // Classic entries: directories ending in -integrity or legacy .tgz files
+    if name.ends_with("-integrity") || name.ends_with(".tgz") {
         if let Some((pkg, ver)) = parse_classic_filename(&name) {
             return Some(format!("{} {}", pkg, ver));
         }
@@ -216,7 +229,8 @@ pub fn package_id(path: &Path) -> Option<super::PackageId> {
         });
     }
 
-    if name.ends_with(".tgz") {
+    // Classic: directories ending in -integrity or legacy .tgz files
+    if name.ends_with("-integrity") || name.ends_with(".tgz") {
         let (pkg, ver) = parse_classic_filename(&name)?;
         return Some(super::PackageId {
             ecosystem: "npm",
@@ -243,26 +257,22 @@ pub fn metadata(path: &Path) -> Vec<MetadataField> {
         return fields;
     }
 
-    if name.ends_with(".tgz") {
+    if name.ends_with("-integrity") || name.ends_with(".tgz") {
         fields.push(MetadataField {
             label: "Format".to_string(),
-            value: "Yarn Classic (.tgz)".to_string(),
+            value: "Yarn Classic".to_string(),
         });
         return fields;
     }
 
-    // Cache root directories: count .zip/.tgz files
+    // Cache root directories: count Berry .zip files and Classic -integrity dirs
     if path.is_dir() {
         if let Ok(entries) = std::fs::read_dir(path) {
             let count = entries
                 .filter_map(|e| e.ok())
                 .filter(|e| {
-                    let p = e.path();
-                    let ext = p
-                        .extension()
-                        .map(|x| x.to_string_lossy().to_string())
-                        .unwrap_or_default();
-                    ext == "zip" || ext == "tgz"
+                    let n = e.file_name().to_string_lossy().to_string();
+                    n.ends_with(".zip") || n.ends_with("-integrity") || n.ends_with(".tgz")
                 })
                 .count();
             if count > 0 {
@@ -372,6 +382,69 @@ mod tests {
     fn parse_classic_invalid_no_npm_prefix() {
         let result = parse_classic_filename("lodash-4.17.21-6382d821f21d.tgz");
         assert_eq!(result, None);
+    }
+
+    // --- Classic -integrity format (real Yarn Classic 1.x on-disk format) ---
+
+    #[test]
+    fn parse_classic_integrity_simple() {
+        let result = parse_classic_filename(
+            "npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity",
+        );
+        assert_eq!(result, Some(("lodash".to_string(), "4.17.21".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_integrity_scoped() {
+        let result = parse_classic_filename(
+            "npm-@babel-core-7.24.0-56cbda6b185ae9d9bed369816a8f4423c5f2ff1b-integrity",
+        );
+        assert_eq!(
+            result,
+            Some(("@babel/core".to_string(), "7.24.0".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_classic_integrity_hyphenated() {
+        let result = parse_classic_filename(
+            "npm-is-even-1.0.0-76b5055fbad8d294a86b6a949015e1c97b717c06-integrity",
+        );
+        assert_eq!(result, Some(("is-even".to_string(), "1.0.0".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_integrity_base64() {
+        let result = parse_classic_filename(
+            "npm-base64-js-1.5.1-1b1b440160a5bf7ad40b650f095963481903930a-integrity",
+        );
+        assert_eq!(result, Some(("base64-js".to_string(), "1.5.1".to_string())));
+    }
+
+    #[test]
+    fn parse_classic_invalid_no_suffix() {
+        // Neither -integrity nor .tgz — should return None
+        let result = parse_classic_filename("npm-lodash-4.17.21-abc123def456");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn semantic_name_classic_integrity_dir() {
+        let path = PathBuf::from(
+            "/Users/me/Library/Caches/Yarn/v6/npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity",
+        );
+        assert_eq!(semantic_name(&path), Some("lodash 4.17.21".into()));
+    }
+
+    #[test]
+    fn package_id_classic_integrity_dir() {
+        let path = PathBuf::from(
+            "/Users/me/Library/Caches/Yarn/v6/npm-@babel-core-7.24.0-56cbda6b185ae9d9bed369816a8f4423c5f2ff1b-integrity",
+        );
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.name, "@babel/core");
+        assert_eq!(id.version, "7.24.0");
+        assert_eq!(id.ecosystem, "npm");
     }
 
     // --- Semantic name ---
@@ -565,13 +638,34 @@ mod tests {
     }
 
     #[test]
+    fn metadata_classic_integrity_shows_format() {
+        let path = PathBuf::from(
+            "/Users/me/Library/Caches/Yarn/v6/npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity",
+        );
+        let fields = metadata(&path);
+        assert!(!fields.is_empty());
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Format" && f.value.contains("Classic"))
+        );
+    }
+
+    #[test]
     fn metadata_cache_dir_counts_packages() {
         let tmp = tempfile::tempdir().unwrap();
         let cache_dir = tmp.path().join("cache");
         std::fs::create_dir_all(&cache_dir).unwrap();
+        // Berry .zip
         std::fs::write(cache_dir.join("lodash-npm-4.17.21-abc123def456.zip"), "x").unwrap();
-        std::fs::write(cache_dir.join("express-npm-4.21.0-def789abc012.zip"), "x").unwrap();
-        std::fs::write(cache_dir.join("npm-lodash-4.17.21-abc123def456.tgz"), "x").unwrap();
+        // Classic -integrity directory
+        std::fs::create_dir_all(
+            cache_dir.join("npm-express-4.21.0-def789abc012def789abc012def789abc012def7-integrity"),
+        )
+        .unwrap();
+        // Legacy .tgz
+        std::fs::write(cache_dir.join("npm-is-even-1.0.0-abc123def456.tgz"), "x").unwrap();
+        // Non-package file
         std::fs::write(cache_dir.join("README.md"), "x").unwrap();
 
         let fields = metadata(&cache_dir);

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -15,7 +15,6 @@ pub enum CacheKind {
     Torch,
     Chroma,
     Prisma,
-    #[allow(dead_code)]
     Yarn,
     #[allow(dead_code)]
     Pnpm,

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -16,7 +16,6 @@ pub enum CacheKind {
     Chroma,
     Prisma,
     Yarn,
-    #[allow(dead_code)]
     Pnpm,
     #[default]
     Unknown,

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -15,6 +15,10 @@ pub enum CacheKind {
     Torch,
     Chroma,
     Prisma,
+    #[allow(dead_code)]
+    Yarn,
+    #[allow(dead_code)]
+    Pnpm,
     #[default]
     Unknown,
 }
@@ -34,6 +38,8 @@ impl CacheKind {
             Self::Torch => "PyTorch",
             Self::Chroma => "Chroma",
             Self::Prisma => "Prisma",
+            Self::Yarn => "Yarn",
+            Self::Pnpm => "pnpm",
             Self::Unknown => "",
         }
     }
@@ -52,6 +58,8 @@ impl CacheKind {
             Self::Torch => "PyTorch — cached model checkpoints and hub downloads",
             Self::Chroma => "Chroma vector DB — cached embedding models",
             Self::Prisma => "Prisma ORM — cached database engine binaries",
+            Self::Yarn => "Yarn package manager — cached packages and metadata",
+            Self::Pnpm => "pnpm package manager — content-addressed package store",
             Self::Unknown => "",
         }
     }
@@ -70,6 +78,8 @@ impl CacheKind {
             Self::Torch => "https://pytorch.org",
             Self::Chroma => "https://www.trychroma.com",
             Self::Prisma => "https://www.prisma.io",
+            Self::Yarn => "https://yarnpkg.com",
+            Self::Pnpm => "https://pnpm.io",
             Self::Unknown => "",
         }
     }
@@ -193,5 +203,19 @@ mod tests {
     #[test]
     fn cache_kind_default_is_unknown() {
         assert_eq!(CacheKind::default(), CacheKind::Unknown);
+    }
+
+    #[test]
+    fn cache_kind_yarn_has_label() {
+        assert_eq!(CacheKind::Yarn.label(), "Yarn");
+        assert!(!CacheKind::Yarn.description().is_empty());
+        assert!(!CacheKind::Yarn.url().is_empty());
+    }
+
+    #[test]
+    fn cache_kind_pnpm_has_label() {
+        assert_eq!(CacheKind::Pnpm.label(), "pnpm");
+        assert!(!CacheKind::Pnpm.description().is_empty());
+        assert!(!CacheKind::Pnpm.url().is_empty());
     }
 }

--- a/src/ui/tree_panel.rs
+++ b/src/ui/tree_panel.rs
@@ -72,9 +72,12 @@ pub fn render(
         let name = &node.name;
 
         // Calculate available space for name
-        // Use display width for Unicode icons (⚠ and ↓ are each 1 column but multi-byte)
-        let icon_display_width = status_icon.chars().count();
-        let prefix_len = indent.len() + arrow.len() + marker.len() + icon_display_width;
+        // Use char count for display width: arrow (▾/▸), marker (●), and status
+        // icons (⚠/↓) are all single-column characters but multi-byte in UTF-8.
+        let prefix_len = indent.len()
+            + arrow.chars().count()
+            + marker.chars().count()
+            + status_icon.chars().count();
         let size_len = size_str.len() + 1; // +1 for padding
         let available = width.saturating_sub(prefix_len + size_len + 1);
         let truncated_name = if name.len() > available {

--- a/src/ui/tree_panel.rs
+++ b/src/ui/tree_panel.rs
@@ -72,7 +72,9 @@ pub fn render(
         let name = &node.name;
 
         // Calculate available space for name
-        let prefix_len = indent.len() + arrow.len() + marker.len() + status_icon.len();
+        // Use display width for Unicode icons (⚠ and ↓ are each 1 column but multi-byte)
+        let icon_display_width = status_icon.chars().count();
+        let prefix_len = indent.len() + arrow.len() + marker.len() + icon_display_width;
         let size_len = size_str.len() + 1; // +1 for padding
         let available = width.saturating_sub(prefix_len + size_len + 1);
         let truncated_name = if name.len() > available {

--- a/tests/e2e_js_providers.rs
+++ b/tests/e2e_js_providers.rs
@@ -118,7 +118,7 @@ fn e2e_yarn_classic_realistic_packages() {
 
     let tmp = tempfile::tempdir().unwrap();
     let project = tmp.path().join("classic");
-    let cache = tmp.path().join("yarn-cache");
+    let cache = tmp.path().join(".yarn-cache");
     std::fs::create_dir_all(&cache).unwrap();
     init_npm_project(&project);
 

--- a/tests/e2e_js_providers.rs
+++ b/tests/e2e_js_providers.rs
@@ -1,154 +1,531 @@
 //! End-to-end tests for Yarn and pnpm providers using real tools.
-//! Requires Yarn and pnpm to be installed.
-//! Run with: cargo test --features e2e --test e2e_js_providers
+//!
+//! These tests install real packages into real caches, then verify the parsers
+//! extract correct names, versions, and ecosystems from actual on-disk formats.
+//!
+//! Requires: npm, yarn (classic), corepack (for berry), pnpm
+//! Run with: cargo test --features e2e --test e2e_js_providers -- --test-threads=1
 #![cfg(feature = "e2e")]
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
+
+// ============================================================
+// Helpers
+// ============================================================
 
 /// Check if a command is available on PATH.
 fn is_available(cmd: &str) -> bool {
-    Command::new("which")
-        .arg(cmd)
+    Command::new(cmd)
+        .arg("--version")
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
 }
 
 /// Run a command in a directory and assert success.
-fn run_in(dir: &std::path::Path, cmd: &str, args: &[&str]) {
+fn run_in(dir: &Path, cmd: &str, args: &[&str]) {
     let output = Command::new(cmd)
         .args(args)
         .current_dir(dir)
+        .env("npm_config_fund", "false")
+        .env("npm_config_audit", "false")
         .output()
-        .unwrap_or_else(|e| panic!("Failed to run {} {:?}: {}", cmd, args, e));
+        .unwrap_or_else(|e| panic!("Failed to run {cmd} {args:?}: {e}"));
     assert!(
         output.status.success(),
-        "{} {:?} failed:\nstdout: {}\nstderr: {}",
-        cmd,
-        args,
+        "{cmd} {args:?} failed:\nstdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
 }
 
-// --- Yarn Classic E2E ---
+/// Run a command and return stdout, or None on failure.
+fn run_stdout(cmd: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(cmd).args(args).output().ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
 
+/// Collect discovered package names from a set of roots.
+fn discovered_names(roots: &[PathBuf]) -> Vec<String> {
+    ccmd::scanner::discover_packages(roots)
+        .into_iter()
+        .map(|(_, id)| id.name)
+        .collect()
+}
+
+/// Collect discovered packages as (name, version, ecosystem) tuples.
+fn discovered_packages(roots: &[PathBuf]) -> Vec<(String, String, &'static str)> {
+    ccmd::scanner::discover_packages(roots)
+        .into_iter()
+        .map(|(_, id)| (id.name, id.version, id.ecosystem))
+        .collect()
+}
+
+/// List filenames in a directory (non-recursive).
+fn list_dir(dir: &Path) -> Vec<String> {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Create a minimal npm project in the given directory.
+fn init_npm_project(dir: &Path) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("package.json"),
+        r#"{"name":"test-project","version":"1.0.0","private":true}"#,
+    )
+    .unwrap();
+}
+
+// ============================================================
+// Yarn Classic (1.x)
+// ============================================================
+
+/// Yarn Classic: simple package, scoped package, hyphenated name
+/// Validates actual .tgz filenames match our `parse_classic_filename` assumptions.
 #[test]
-fn e2e_yarn_classic_cache_detection() {
+fn e2e_yarn_classic_realistic_packages() {
     if !is_available("yarn") {
         eprintln!("SKIP: yarn not installed");
         return;
     }
-
-    // Check if this is Yarn Classic (1.x)
-    let output = Command::new("yarn").arg("--version").output().unwrap();
-    let version = String::from_utf8_lossy(&output.stdout);
+    let version = run_stdout("yarn", &["--version"]).unwrap_or_default();
     if !version.starts_with('1') {
-        eprintln!("SKIP: yarn is not Classic (1.x), got {}", version.trim());
+        eprintln!("SKIP: yarn is not Classic (1.x), got {version}");
         return;
     }
 
     let tmp = tempfile::tempdir().unwrap();
-    let project = tmp.path().join("classic-project");
-    std::fs::create_dir_all(&project).unwrap();
+    let project = tmp.path().join("classic");
+    init_npm_project(&project);
 
-    // Initialize project and install a package
-    run_in(&project, "npm", &["init", "-y"]);
-    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
+    // Install a mix of package types that stress the parser:
+    // - simple name: lodash
+    // - scoped package: @babel/core
+    // - hyphenated name: is-even
+    // - name containing digits: base64-js
+    run_in(
+        &project,
+        "yarn",
+        &[
+            "add",
+            "lodash@4.17.21",
+            "@babel/core@7.24.0",
+            "is-even@1.0.0",
+            "base64-js@1.5.1",
+        ],
+    );
 
-    // Find yarn cache dir
-    let output = Command::new("yarn")
-        .args(["cache", "dir"])
-        .output()
+    // Find the actual cache directory
+    let cache_dir = run_stdout("yarn", &["cache", "dir"]).expect("yarn cache dir failed");
+    let cache_path = PathBuf::from(&cache_dir);
+    assert!(cache_path.exists(), "Yarn cache dir missing: {cache_dir}");
+
+    // Verify the actual filenames on disk are what we expect
+    let files = list_dir(&cache_path);
+    eprintln!(
+        "Yarn Classic cache files (sample): {:?}",
+        &files[..files.len().min(10)]
+    );
+
+    // Yarn Classic uses directories named npm-<name>-<version>-<hash>-integrity
+    let integrity_dirs: Vec<&String> = files.iter().filter(|f| f.ends_with("-integrity")).collect();
+    assert!(
+        !integrity_dirs.is_empty(),
+        "Expected -integrity directories in Yarn Classic cache, got: {files:?}"
+    );
+    for f in &integrity_dirs {
+        assert!(
+            f.starts_with("npm-"),
+            "Yarn Classic entries should start with 'npm-': {f}"
+        );
+    }
+
+    // Now verify the scanner discovers all packages correctly
+    let packages = discovered_packages(&[cache_path.clone()]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(names.contains(&"lodash"), "Should find lodash: {names:?}");
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {names:?}"
+    );
+    assert!(names.contains(&"is-even"), "Should find is-even: {names:?}");
+    assert!(
+        names.contains(&"base64-js"),
+        "Should find base64-js: {names:?}"
+    );
+
+    // Verify versions are correct
+    let lodash = packages.iter().find(|(n, _, _)| n == "lodash").unwrap();
+    assert_eq!(lodash.1, "4.17.21", "lodash version mismatch");
+    assert_eq!(lodash.2, "npm", "lodash ecosystem should be npm");
+
+    let babel = packages
+        .iter()
+        .find(|(n, _, _)| n == "@babel/core")
         .unwrap();
-    let cache_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let cache_path = std::path::PathBuf::from(&cache_dir);
+    assert_eq!(babel.1, "7.24.0", "babel version mismatch");
 
-    assert!(
-        cache_path.exists(),
-        "Yarn cache dir should exist: {}",
-        cache_dir
-    );
+    let is_even = packages.iter().find(|(n, _, _)| n == "is-even").unwrap();
+    assert_eq!(is_even.1, "1.0.0");
 
-    // Scan for packages
-    let packages = ccmd::scanner::discover_packages(&[cache_path]);
-    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
-    assert!(
-        names.contains(&"is-even"),
-        "Should find is-even in Yarn Classic cache: {:?}",
-        names
-    );
+    let base64 = packages.iter().find(|(n, _, _)| n == "base64-js").unwrap();
+    assert_eq!(base64.1, "1.5.1");
 
-    // Clean up: remove the cached package
-    let _ = Command::new("yarn")
-        .args(["cache", "clean", "is-even"])
-        .output();
+    // Clean up global cache
+    let _ = Command::new("yarn").args(["cache", "clean"]).output();
 }
 
-// --- Yarn Berry E2E ---
+// ============================================================
+// Yarn Berry (2+)
+// ============================================================
 
+/// Yarn Berry: simple, scoped, and hyphenated packages
+/// Validates actual .zip filenames match our `parse_berry_filename` assumptions.
 #[test]
-fn e2e_yarn_berry_cache_detection() {
+fn e2e_yarn_berry_realistic_packages() {
     if !is_available("corepack") {
         eprintln!("SKIP: corepack not available");
         return;
     }
 
     let tmp = tempfile::tempdir().unwrap();
-    let project = tmp.path().join("berry-project");
-    std::fs::create_dir_all(&project).unwrap();
+    let project = tmp.path().join("berry");
+    init_npm_project(&project);
 
-    // Initialize Berry project
-    run_in(&project, "npm", &["init", "-y"]);
+    // Set up Berry
     run_in(&project, "corepack", &["enable"]);
     run_in(&project, "yarn", &["set", "version", "berry"]);
-    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
 
-    // Berry cache is per-project at .yarn/cache/
+    // Disable PnP to avoid node resolution issues, use node_modules
+    std::fs::write(
+        project.join(".yarnrc.yml"),
+        "nodeLinker: node-modules\nenableGlobalCache: false\n",
+    )
+    .unwrap();
+
+    // Install packages that stress the parser
+    run_in(
+        &project,
+        "yarn",
+        &[
+            "add",
+            "lodash@4.17.21",
+            "@babel/core@7.24.0",
+            "is-even@1.0.0",
+            "base64-js@1.5.1",
+        ],
+    );
+
+    // Berry cache is per-project
     let cache_path = project.join(".yarn/cache");
     assert!(cache_path.exists(), ".yarn/cache should exist");
 
-    // Scan for packages
-    let packages = ccmd::scanner::discover_packages(&[project.join(".yarn")]);
-    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
-    assert!(
-        names.contains(&"is-even"),
-        "Should find is-even in Berry cache: {:?}",
-        names
+    // Verify the actual filenames on disk
+    let files = list_dir(&cache_path);
+    eprintln!(
+        "Yarn Berry cache files (sample): {:?}",
+        &files[..files.len().min(10)]
     );
+
+    let zip_files: Vec<&String> = files.iter().filter(|f| f.ends_with(".zip")).collect();
+    assert!(
+        !zip_files.is_empty(),
+        "Expected .zip files in Berry cache, got: {files:?}"
+    );
+
+    // Verify the -npm- marker is present in zip filenames
+    for f in &zip_files {
+        assert!(
+            f.contains("-npm-"),
+            "Berry .zip should contain '-npm-': {f}"
+        );
+    }
+
+    // Verify scanner discovers packages
+    let packages = discovered_packages(&[project.join(".yarn")]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(names.contains(&"lodash"), "Should find lodash: {names:?}");
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {names:?}"
+    );
+    assert!(names.contains(&"is-even"), "Should find is-even: {names:?}");
+    assert!(
+        names.contains(&"base64-js"),
+        "Should find base64-js: {names:?}"
+    );
+
+    // Verify versions
+    let lodash = packages.iter().find(|(n, _, _)| n == "lodash").unwrap();
+    assert_eq!(lodash.1, "4.17.21");
+    assert_eq!(lodash.2, "npm");
+
+    let babel = packages
+        .iter()
+        .find(|(n, _, _)| n == "@babel/core")
+        .unwrap();
+    assert_eq!(babel.1, "7.24.0");
 }
 
-// --- pnpm E2E ---
-
+/// Yarn Berry: package with `-npm-` in the name (the bug we fixed)
 #[test]
-fn e2e_pnpm_virtual_store_detection() {
+fn e2e_yarn_berry_npm_in_package_name() {
+    if !is_available("corepack") {
+        eprintln!("SKIP: corepack not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("berry-npm-name");
+    init_npm_project(&project);
+
+    run_in(&project, "corepack", &["enable"]);
+    run_in(&project, "yarn", &["set", "version", "berry"]);
+    std::fs::write(
+        project.join(".yarnrc.yml"),
+        "nodeLinker: node-modules\nenableGlobalCache: false\n",
+    )
+    .unwrap();
+
+    // npm-run-all has "npm" in its name — this is the exact bug we fixed
+    run_in(&project, "yarn", &["add", "npm-run-all@4.1.5"]);
+
+    let cache_path = project.join(".yarn/cache");
+    let files = list_dir(&cache_path);
+    eprintln!("Berry cache with npm-run-all: {files:?}");
+
+    let packages = discovered_packages(&[project.join(".yarn")]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(
+        names.contains(&"npm-run-all"),
+        "Should find npm-run-all despite '-npm-' in name: {names:?}"
+    );
+
+    let pkg = packages
+        .iter()
+        .find(|(n, _, _)| n == "npm-run-all")
+        .unwrap();
+    assert_eq!(pkg.1, "4.1.5");
+}
+
+// ============================================================
+// pnpm
+// ============================================================
+
+/// pnpm: simple, scoped, and hyphenated packages in virtual store
+/// Validates actual directory names match our `parse_virtual_store_name` assumptions.
+#[test]
+fn e2e_pnpm_realistic_packages() {
     if !is_available("pnpm") {
         eprintln!("SKIP: pnpm not installed");
         return;
     }
 
     let tmp = tempfile::tempdir().unwrap();
-    let project = tmp.path().join("pnpm-project");
-    std::fs::create_dir_all(&project).unwrap();
+    let project = tmp.path().join("pnpm-basic");
+    init_npm_project(&project);
 
-    // Initialize and install
-    run_in(&project, "pnpm", &["init"]);
-    run_in(&project, "pnpm", &["add", "is-even@1.0.0"]);
+    run_in(
+        &project,
+        "pnpm",
+        &[
+            "add",
+            "lodash@4.17.21",
+            "@babel/core@7.24.0",
+            "is-even@1.0.0",
+            "base64-js@1.5.1",
+        ],
+    );
 
-    // pnpm creates node_modules/.pnpm/
     let pnpm_dir = project.join("node_modules/.pnpm");
     assert!(pnpm_dir.exists(), "node_modules/.pnpm should exist");
 
-    // Scan for packages
-    let packages = ccmd::scanner::discover_packages(&[project.join("node_modules/.pnpm")]);
-    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    // Verify actual directory naming convention
+    let entries = list_dir(&pnpm_dir);
+    eprintln!(
+        "pnpm virtual store entries (sample): {:?}",
+        &entries[..entries.len().min(15)]
+    );
+
+    // Verify @ naming convention
+    let at_entries: Vec<&String> = entries.iter().filter(|e| e.contains('@')).collect();
     assert!(
-        names.contains(&"is-even"),
-        "Should find is-even in pnpm virtual store: {:?}",
-        names
+        !at_entries.is_empty(),
+        "Expected @-named entries in .pnpm: {entries:?}"
+    );
+
+    // Verify scoped packages use + separator
+    let scoped: Vec<&&String> = at_entries.iter().filter(|e| e.starts_with('@')).collect();
+    assert!(
+        !scoped.is_empty(),
+        "Expected scoped packages in .pnpm: {entries:?}"
+    );
+    for s in &scoped {
+        assert!(
+            s.contains('+'),
+            "Scoped pnpm entries should use '+' separator: {s}"
+        );
+    }
+
+    // Verify scanner finds all packages
+    let packages = discovered_packages(&[pnpm_dir.clone()]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(names.contains(&"lodash"), "Should find lodash: {names:?}");
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {names:?}"
+    );
+    assert!(names.contains(&"is-even"), "Should find is-even: {names:?}");
+    assert!(
+        names.contains(&"base64-js"),
+        "Should find base64-js: {names:?}"
+    );
+
+    // Verify versions
+    let lodash = packages.iter().find(|(n, _, _)| n == "lodash").unwrap();
+    assert_eq!(lodash.1, "4.17.21");
+    assert_eq!(lodash.2, "npm");
+
+    let babel = packages
+        .iter()
+        .find(|(n, _, _)| n == "@babel/core")
+        .unwrap();
+    assert_eq!(babel.1, "7.24.0");
+}
+
+/// pnpm: peer dependency suffixes (the bug we fixed)
+/// Installs packages with peer deps to verify strip_peer_deps works on real dirs.
+#[test]
+fn e2e_pnpm_peer_dependencies() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("pnpm-peers");
+    init_npm_project(&project);
+
+    // react-dom has a peer dep on react — pnpm encodes this in the directory name
+    run_in(
+        &project,
+        "pnpm",
+        &["add", "react@18.2.0", "react-dom@18.2.0"],
+    );
+
+    let pnpm_dir = project.join("node_modules/.pnpm");
+    let entries = list_dir(&pnpm_dir);
+    eprintln!(
+        "pnpm entries with peer deps: {:?}",
+        &entries[..entries.len().min(20)]
+    );
+
+    // Find the react-dom entry — it should have a peer dep suffix with '_'
+    let react_dom_entries: Vec<&String> = entries
+        .iter()
+        .filter(|e| e.starts_with("react-dom@"))
+        .collect();
+    assert!(
+        !react_dom_entries.is_empty(),
+        "Should find react-dom@ entry: {entries:?}"
+    );
+
+    // Log the actual format for debugging
+    for entry in &react_dom_entries {
+        eprintln!("react-dom entry: {entry}");
+    }
+
+    // Verify scanner correctly parses react-dom despite peer dep suffix
+    let packages = discovered_packages(&[pnpm_dir]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(
+        names.contains(&"react-dom"),
+        "Should find react-dom after stripping peer deps: {names:?}"
+    );
+    assert!(names.contains(&"react"), "Should find react: {names:?}");
+
+    // Verify version is correct (not polluted by peer dep suffix)
+    let react_dom = packages.iter().find(|(n, _, _)| n == "react-dom").unwrap();
+    assert_eq!(
+        react_dom.1, "18.2.0",
+        "react-dom version should be 18.2.0, not include peer dep suffix"
     );
 }
 
+/// pnpm: scoped packages with peer deps
+#[test]
+fn e2e_pnpm_scoped_with_peers() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("pnpm-scoped-peers");
+    init_npm_project(&project);
+
+    // @testing-library/react has peer deps on react and react-dom
+    run_in(
+        &project,
+        "pnpm",
+        &[
+            "add",
+            "react@18.2.0",
+            "react-dom@18.2.0",
+            "@testing-library/react@14.2.0",
+        ],
+    );
+
+    let pnpm_dir = project.join("node_modules/.pnpm");
+    let entries = list_dir(&pnpm_dir);
+
+    // Find the scoped entry with peer deps
+    let tl_entries: Vec<&String> = entries
+        .iter()
+        .filter(|e| e.starts_with("@testing-library+react@"))
+        .collect();
+    assert!(
+        !tl_entries.is_empty(),
+        "Should find @testing-library+react@ entry: {entries:?}"
+    );
+    for entry in &tl_entries {
+        eprintln!("@testing-library/react entry: {entry}");
+    }
+
+    let packages = discovered_packages(&[pnpm_dir]);
+    let names: Vec<&str> = packages.iter().map(|(n, _, _)| n.as_str()).collect();
+
+    assert!(
+        names.contains(&"@testing-library/react"),
+        "Should find @testing-library/react: {names:?}"
+    );
+
+    let pkg = packages
+        .iter()
+        .find(|(n, _, _)| n == "@testing-library/react")
+        .unwrap();
+    assert_eq!(pkg.1, "14.2.0");
+    assert_eq!(pkg.2, "npm");
+}
+
+/// pnpm: store path auto-detection
 #[test]
 fn e2e_pnpm_store_path_detection() {
     if !is_available("pnpm") {
@@ -156,17 +533,59 @@ fn e2e_pnpm_store_path_detection() {
         return;
     }
 
-    let output = Command::new("pnpm")
-        .args(["store", "path"])
-        .output()
-        .unwrap();
-    if output.status.success() {
-        let store_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let path = std::path::PathBuf::from(&store_path);
-        assert!(
-            path.exists(),
-            "pnpm store path should exist: {}",
-            store_path
-        );
+    let store_path = run_stdout("pnpm", &["store", "path"]);
+    if let Some(path_str) = store_path {
+        let path = PathBuf::from(&path_str);
+        assert!(path.exists(), "pnpm store path should exist: {path_str}");
     }
+}
+
+// ============================================================
+// Cross-provider deduplication with real tools
+// ============================================================
+
+/// Verify that the same package installed via npm and yarn is deduplicated.
+#[test]
+fn e2e_dedup_across_npm_and_yarn() {
+    if !is_available("yarn") || !is_available("npm") {
+        eprintln!("SKIP: yarn or npm not installed");
+        return;
+    }
+    let version = run_stdout("yarn", &["--version"]).unwrap_or_default();
+    if !version.starts_with('1') {
+        eprintln!("SKIP: need Yarn Classic for this test, got {version}");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Install lodash via Yarn Classic (goes to global yarn cache)
+    let yarn_project = tmp.path().join("yarn-dedup");
+    init_npm_project(&yarn_project);
+    run_in(&yarn_project, "yarn", &["add", "lodash@4.17.21"]);
+
+    // Install lodash via npm/npx (goes to .npm cache)
+    let npm_project = tmp.path().join("npm-dedup");
+    init_npm_project(&npm_project);
+    run_in(&npm_project, "npm", &["install", "lodash@4.17.21"]);
+
+    let yarn_cache = run_stdout("yarn", &["cache", "dir"])
+        .map(PathBuf::from)
+        .expect("yarn cache dir");
+    let npm_modules = npm_project.join("node_modules");
+
+    // Scan both caches together
+    let packages = ccmd::scanner::discover_packages(&[yarn_cache, npm_modules]);
+
+    let lodash_count = packages
+        .iter()
+        .filter(|(_, id)| id.name == "lodash" && id.version == "4.17.21")
+        .count();
+
+    assert_eq!(
+        lodash_count, 1,
+        "lodash@4.17.21 should be deduplicated across npm and yarn, got {lodash_count}"
+    );
+
+    let _ = Command::new("yarn").args(["cache", "clean"]).output();
 }

--- a/tests/e2e_js_providers.rs
+++ b/tests/e2e_js_providers.rs
@@ -25,11 +25,21 @@ fn is_available(cmd: &str) -> bool {
 
 /// Run a command in a directory and assert success.
 fn run_in(dir: &Path, cmd: &str, args: &[&str]) {
-    let output = Command::new(cmd)
+    run_in_with_env(dir, cmd, args, &[]);
+}
+
+/// Run a command in a directory with extra env vars and assert success.
+fn run_in_with_env(dir: &Path, cmd: &str, args: &[&str], env: &[(&str, &str)]) {
+    let mut command = Command::new(cmd);
+    command
         .args(args)
         .current_dir(dir)
         .env("npm_config_fund", "false")
-        .env("npm_config_audit", "false")
+        .env("npm_config_audit", "false");
+    for (k, v) in env {
+        command.env(k, v);
+    }
+    let output = command
         .output()
         .unwrap_or_else(|e| panic!("Failed to run {cmd} {args:?}: {e}"));
     assert!(
@@ -108,14 +118,19 @@ fn e2e_yarn_classic_realistic_packages() {
 
     let tmp = tempfile::tempdir().unwrap();
     let project = tmp.path().join("classic");
+    let cache = tmp.path().join("yarn-cache");
+    std::fs::create_dir_all(&cache).unwrap();
     init_npm_project(&project);
+
+    let cache_str = cache.to_string_lossy().to_string();
+    let env = [("YARN_CACHE_FOLDER", cache_str.as_str())];
 
     // Install a mix of package types that stress the parser:
     // - simple name: lodash
     // - scoped package: @babel/core
     // - hyphenated name: is-even
     // - name containing digits: base64-js
-    run_in(
+    run_in_with_env(
         &project,
         "yarn",
         &[
@@ -125,12 +140,14 @@ fn e2e_yarn_classic_realistic_packages() {
             "is-even@1.0.0",
             "base64-js@1.5.1",
         ],
+        &env,
     );
 
-    // Find the actual cache directory
-    let cache_dir = run_stdout("yarn", &["cache", "dir"]).expect("yarn cache dir failed");
-    let cache_path = PathBuf::from(&cache_dir);
-    assert!(cache_path.exists(), "Yarn cache dir missing: {cache_dir}");
+    let cache_path = cache.join("v6");
+    assert!(
+        cache_path.exists(),
+        "Yarn cache dir missing: {cache_path:?}"
+    );
 
     // Verify the actual filenames on disk are what we expect
     let files = list_dir(&cache_path);
@@ -184,8 +201,7 @@ fn e2e_yarn_classic_realistic_packages() {
     let base64 = packages.iter().find(|(n, _, _)| n == "base64-js").unwrap();
     assert_eq!(base64.1, "1.5.1");
 
-    // Clean up global cache
-    let _ = Command::new("yarn").args(["cache", "clean"]).output();
+    // tempdir cleanup handles the isolated cache — no global cache was touched
 }
 
 // ============================================================

--- a/tests/e2e_js_providers.rs
+++ b/tests/e2e_js_providers.rs
@@ -1,0 +1,172 @@
+//! End-to-end tests for Yarn and pnpm providers using real tools.
+//! Requires Yarn and pnpm to be installed.
+//! Run with: cargo test --features e2e --test e2e_js_providers
+#![cfg(feature = "e2e")]
+
+use std::process::Command;
+
+/// Check if a command is available on PATH.
+fn is_available(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Run a command in a directory and assert success.
+fn run_in(dir: &std::path::Path, cmd: &str, args: &[&str]) {
+    let output = Command::new(cmd)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("Failed to run {} {:?}: {}", cmd, args, e));
+    assert!(
+        output.status.success(),
+        "{} {:?} failed:\nstdout: {}\nstderr: {}",
+        cmd,
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// --- Yarn Classic E2E ---
+
+#[test]
+fn e2e_yarn_classic_cache_detection() {
+    if !is_available("yarn") {
+        eprintln!("SKIP: yarn not installed");
+        return;
+    }
+
+    // Check if this is Yarn Classic (1.x)
+    let output = Command::new("yarn").arg("--version").output().unwrap();
+    let version = String::from_utf8_lossy(&output.stdout);
+    if !version.starts_with('1') {
+        eprintln!("SKIP: yarn is not Classic (1.x), got {}", version.trim());
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("classic-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize project and install a package
+    run_in(&project, "npm", &["init", "-y"]);
+    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
+
+    // Find yarn cache dir
+    let output = Command::new("yarn")
+        .args(["cache", "dir"])
+        .output()
+        .unwrap();
+    let cache_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let cache_path = std::path::PathBuf::from(&cache_dir);
+
+    assert!(
+        cache_path.exists(),
+        "Yarn cache dir should exist: {}",
+        cache_dir
+    );
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[cache_path]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in Yarn Classic cache: {:?}",
+        names
+    );
+
+    // Clean up: remove the cached package
+    let _ = Command::new("yarn")
+        .args(["cache", "clean", "is-even"])
+        .output();
+}
+
+// --- Yarn Berry E2E ---
+
+#[test]
+fn e2e_yarn_berry_cache_detection() {
+    if !is_available("corepack") {
+        eprintln!("SKIP: corepack not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("berry-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize Berry project
+    run_in(&project, "npm", &["init", "-y"]);
+    run_in(&project, "corepack", &["enable"]);
+    run_in(&project, "yarn", &["set", "version", "berry"]);
+    run_in(&project, "yarn", &["add", "is-even@1.0.0"]);
+
+    // Berry cache is per-project at .yarn/cache/
+    let cache_path = project.join(".yarn/cache");
+    assert!(cache_path.exists(), ".yarn/cache should exist");
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[project.join(".yarn")]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in Berry cache: {:?}",
+        names
+    );
+}
+
+// --- pnpm E2E ---
+
+#[test]
+fn e2e_pnpm_virtual_store_detection() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("pnpm-project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    // Initialize and install
+    run_in(&project, "pnpm", &["init"]);
+    run_in(&project, "pnpm", &["add", "is-even@1.0.0"]);
+
+    // pnpm creates node_modules/.pnpm/
+    let pnpm_dir = project.join("node_modules/.pnpm");
+    assert!(pnpm_dir.exists(), "node_modules/.pnpm should exist");
+
+    // Scan for packages
+    let packages = ccmd::scanner::discover_packages(&[project.join("node_modules/.pnpm")]);
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"is-even"),
+        "Should find is-even in pnpm virtual store: {:?}",
+        names
+    );
+}
+
+#[test]
+fn e2e_pnpm_store_path_detection() {
+    if !is_available("pnpm") {
+        eprintln!("SKIP: pnpm not installed");
+        return;
+    }
+
+    let output = Command::new("pnpm")
+        .args(["store", "path"])
+        .output()
+        .unwrap();
+    if output.status.success() {
+        let store_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = std::path::PathBuf::from(&store_path);
+        assert!(
+            path.exists(),
+            "pnpm store path should exist: {}",
+            store_path
+        );
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -611,6 +611,51 @@ fn osv_query_finds_urllib3_vulns() {
     }
 }
 
+/// Helper to create a fake Yarn Berry cache structure.
+fn create_yarn_berry_cache(root: &std::path::Path) {
+    let yarn_cache = root.join(".yarn/cache");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(
+        yarn_cache.join("lodash-npm-4.17.21-6382d821f21d.zip"),
+        "fake zip contents",
+    )
+    .unwrap();
+    std::fs::write(
+        yarn_cache.join("@babel-core-npm-7.24.0-abc123def456.zip"),
+        "fake zip contents",
+    )
+    .unwrap();
+}
+
+/// Helper to create a fake Yarn Classic cache structure.
+fn create_yarn_classic_cache(root: &std::path::Path) {
+    let yarn_cache = root.join(".yarn-cache/v6");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(
+        yarn_cache.join("npm-express-4.21.0-abcdef123456.tgz"),
+        "fake tgz contents",
+    )
+    .unwrap();
+}
+
+/// Helper to create a fake pnpm cache structure.
+fn create_pnpm_cache(root: &std::path::Path) {
+    // Virtual store
+    let pnpm_vs = root.join("node_modules/.pnpm");
+    let lodash = pnpm_vs.join("lodash@4.17.21/node_modules/lodash");
+    std::fs::create_dir_all(&lodash).unwrap();
+    std::fs::write(lodash.join("index.js"), "module.exports = {}").unwrap();
+
+    let babel = pnpm_vs.join("@babel+core@7.24.0/node_modules/@babel/core");
+    std::fs::create_dir_all(&babel).unwrap();
+    std::fs::write(babel.join("index.js"), "module.exports = {}").unwrap();
+
+    // Content store
+    let store = root.join(".pnpm-store/v3/files/ab");
+    std::fs::create_dir_all(&store).unwrap();
+    std::fs::write(store.join("cd1234abcdef"), "blob content").unwrap();
+}
+
 /// Create a fake npx cache with node_modules for npm scanning tests.
 fn create_npx_cache(root: &std::path::Path) {
     // Root must be named .npm for detect() to identify children as CacheKind::Npm
@@ -717,4 +762,141 @@ fn npm_dep_depth_in_metadata() {
     let depth_field = meta.iter().find(|f| f.label == "Dep depth");
     assert!(depth_field.is_some());
     assert!(depth_field.unwrap().value.contains("transitive"));
+}
+
+#[test]
+fn yarn_discover_packages_finds_berry_zips() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_berry_cache(tmp.path());
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().join(".yarn")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(names.contains(&"lodash"), "Should find lodash: {:?}", names);
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {:?}",
+        names
+    );
+    assert_eq!(
+        packages
+            .iter()
+            .filter(|(_, id)| id.ecosystem == "npm")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn yarn_discover_packages_finds_classic_tgz() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_classic_cache(tmp.path());
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().join(".yarn-cache")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(
+        names.contains(&"express"),
+        "Should find express: {:?}",
+        names
+    );
+}
+
+#[test]
+fn pnpm_discover_packages_finds_virtual_store() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_pnpm_cache(tmp.path());
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().join("node_modules/.pnpm")]);
+
+    let names: Vec<&str> = packages.iter().map(|(_, id)| id.name.as_str()).collect();
+    assert!(names.contains(&"lodash"), "Should find lodash: {:?}", names);
+    assert!(
+        names.contains(&"@babel/core"),
+        "Should find @babel/core: {:?}",
+        names
+    );
+}
+
+#[test]
+fn pnpm_content_store_returns_no_packages() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_pnpm_cache(tmp.path());
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().join(".pnpm-store")]);
+
+    assert_eq!(packages.len(), 0, "Store blobs should not yield packages");
+}
+
+#[test]
+fn scanner_expand_yarn_berry_shows_semantic_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_yarn_berry_cache(tmp.path());
+
+    let cache_path = tmp.path().join(".yarn/cache");
+
+    let (result_tx, result_rx) = mpsc::channel();
+    let scan_tx = ccmd::scanner::start(result_tx);
+
+    scan_tx
+        .send(ccmd::scanner::ScanRequest::ExpandNode(cache_path))
+        .unwrap();
+
+    let result = result_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    match result {
+        ccmd::scanner::ScanResult::ChildrenScanned(_, children) => {
+            let names: Vec<&str> = children.iter().map(|n| n.name.as_str()).collect();
+            assert!(
+                names
+                    .iter()
+                    .any(|n| n.contains("lodash") && n.contains("4.17.21")),
+                "Should show 'lodash 4.17.21': {:?}",
+                names
+            );
+            assert!(
+                names.iter().any(|n| n.contains("@babel/core")),
+                "Should show '@babel/core 7.24.0': {:?}",
+                names
+            );
+            for child in &children {
+                assert_eq!(
+                    child.kind,
+                    ccmd::tree::node::CacheKind::Yarn,
+                    "All children should be detected as Yarn: {:?}",
+                    child.name
+                );
+            }
+        }
+        _ => panic!("Expected ChildrenScanned"),
+    }
+}
+
+#[test]
+fn dedup_across_npm_and_yarn_caches() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // npm: express via node_modules
+    let npm_dir = tmp.path().join(".npm/_npx/abc/node_modules/express");
+    std::fs::create_dir_all(&npm_dir).unwrap();
+    std::fs::write(
+        npm_dir.join("package.json"),
+        r#"{"name":"express","version":"4.21.0"}"#,
+    )
+    .unwrap();
+
+    // yarn: express via berry zip
+    let yarn_cache = tmp.path().join(".yarn/cache");
+    std::fs::create_dir_all(&yarn_cache).unwrap();
+    std::fs::write(yarn_cache.join("express-npm-4.21.0-abcdef123456.zip"), "z").unwrap();
+
+    let packages = ccmd::scanner::discover_packages(&[tmp.path().to_path_buf()]);
+
+    let express_count = packages
+        .iter()
+        .filter(|(_, id)| id.name == "express" && id.version == "4.21.0")
+        .count();
+    assert_eq!(
+        express_count, 1,
+        "express@4.21.0 should be deduplicated across npm and yarn"
+    );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -631,9 +631,9 @@ fn create_yarn_berry_cache(root: &std::path::Path) {
 fn create_yarn_classic_cache(root: &std::path::Path) {
     let yarn_cache = root.join(".yarn-cache/v6");
     std::fs::create_dir_all(&yarn_cache).unwrap();
-    std::fs::write(
-        yarn_cache.join("npm-express-4.21.0-abcdef123456.tgz"),
-        "fake tgz contents",
+    // Real Yarn Classic format: directories named npm-<name>-<version>-<hash>-integrity
+    std::fs::create_dir_all(
+        yarn_cache.join("npm-express-4.21.0-abcdef123456abcdef123456abcdef123456abcd-integrity"),
     )
     .unwrap();
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -788,7 +788,7 @@ fn yarn_discover_packages_finds_berry_zips() {
 }
 
 #[test]
-fn yarn_discover_packages_finds_classic_tgz() {
+fn yarn_discover_packages_finds_classic_cache() {
     let tmp = tempfile::tempdir().unwrap();
     create_yarn_classic_cache(tmp.path());
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -872,6 +872,49 @@ fn scanner_expand_yarn_berry_shows_semantic_names() {
 }
 
 #[test]
+fn scanner_expand_pnpm_virtual_store_shows_semantic_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_pnpm_cache(tmp.path());
+
+    let pnpm_path = tmp.path().join("node_modules/.pnpm");
+
+    let (result_tx, result_rx) = mpsc::channel();
+    let scan_tx = ccmd::scanner::start(result_tx);
+
+    scan_tx
+        .send(ccmd::scanner::ScanRequest::ExpandNode(pnpm_path))
+        .unwrap();
+
+    let result = result_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+    match result {
+        ccmd::scanner::ScanResult::ChildrenScanned(_, children) => {
+            let names: Vec<&str> = children.iter().map(|n| n.name.as_str()).collect();
+            assert!(
+                names
+                    .iter()
+                    .any(|n| n.contains("lodash") && n.contains("4.17.21")),
+                "Should show 'lodash 4.17.21': {:?}",
+                names
+            );
+            assert!(
+                names.iter().any(|n| n.contains("@babel/core")),
+                "Should show '@babel/core 7.24.0': {:?}",
+                names
+            );
+            for child in &children {
+                assert_eq!(
+                    child.kind,
+                    ccmd::tree::node::CacheKind::Pnpm,
+                    "All children should be detected as Pnpm: {:?}",
+                    child.name
+                );
+            }
+        }
+        _ => panic!("Expected ChildrenScanned"),
+    }
+}
+
+#[test]
 fn dedup_across_npm_and_yarn_caches() {
     let tmp = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

- Add **Yarn provider** supporting both Classic (`~/Library/Caches/Yarn/v6`) and Berry (`.yarn/berry/cache`) cache formats with semantic naming, package ID extraction, and scoped package resolution
- Add **pnpm provider** supporting content-addressable stores (v3–v10+) and virtual stores (`node_modules/.pnpm`), with index file parsing for vulnerability/outdated scanning
- **Auto-detect** Yarn and pnpm cache paths at startup via CLI probes (`yarn cache dir`, `pnpm store path`) with platform-specific fallbacks
- Fix **tree panel alignment** when Unicode status icons (⚠↓) are present
- Deduplicate overlapping cache roots (e.g. `~/Library/Caches/Yarn` vs `~/Library/Caches/Yarn/v6`)

## What's included

- `src/providers/yarn.rs` — Yarn Classic + Berry filename parsing, `semantic_name`, `package_id`, `metadata`
- `src/providers/pnpm.rs` — virtual store + v10 index file parsing, content-addressable store display
- `src/config.rs` — CLI-based cache path detection, `is_ancestor_or_descendant` dedup helper
- `src/providers/mod.rs` — `CacheKind::Yarn`/`CacheKind::Pnpm` detection, dispatch, safety levels
- `src/ui/tree_panel.rs` — Unicode icon width fix (`chars().count()` vs byte `len()`)
- `tests/integration.rs` — fixture-based integration tests for both providers
- `tests/e2e_js_providers.rs` — E2E tests using real `yarn`/`pnpm` installs
- `.github/workflows/ci.yml` — new E2E test job for JS provider tests

## Test plan

- [x] 1128 unit/integration tests passing
- [x] Clippy clean, cargo fmt clean
- [x] Adversarial tests for edge cases (injection, malformed filenames, empty inputs)
- [x] E2E tests install real packages and verify provider output
- [x] Manual testing: pnpm store shows vulnerability scanning (lodash CVEs detected)
- [x] Manual testing: tree alignment correct with/without status icons
- [ ] CI passes on push

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)