### PR TITLE
feat: add Bun package manager provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 ### Browse and Understand
 
 - **Two-pane TUI** — navigable tree on the left, details on the right
-- **12 cache providers** — semantic names instead of hash directories
+- **15 cache providers** — semantic names instead of hash directories
 - **Safety levels** — green (safe to delete), yellow (may cause rebuilds), red (contains state)
 - **Sort** by size, name, or last modified
 - **Search** with `/` — case-insensitive filter across the tree
@@ -276,7 +276,7 @@ src/
 │   ├── pip.rs, uv.rs    # Python package providers
 │   ├── npm.rs           # npm + npx + node_modules scanning
 │   ├── cargo.rs         # Rust crate provider
-│   └── ...              # 7 more providers
+│   └── ...              # 10 more providers
 ├── security/
 │   ├── mod.rs           # Scan orchestration, vulnerability filtering
 │   ├── osv.rs           # OSV.dev API, version comparison, fix extraction

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Developer machines accumulate tens of gigabytes of invisible cache data — ML m
 ## Why
 
 - **ML models** (HuggingFace, PyTorch, Whisper) — tens of GB you forgot about
-- **Package caches** (pip, uv, npm, Cargo, Homebrew) — old versions with known CVEs
+- **Package caches** (pip, uv, npm, Yarn, pnpm, Bun, Cargo, Homebrew) — old versions with known CVEs
 - **npm supply chain risk** — transitive deps with install scripts hiding in npx cache
 - **Build artifacts** (pre-commit hooks, Prisma engines) — stale and re-downloadable
 
@@ -114,6 +114,9 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 | PyTorch | `~/.cache/torch` | Model checkpoints |
 | Chroma | `~/.cache/chroma` | Embedding models |
 | Prisma | `~/.cache/prisma` | Engine versions |
+| Yarn | `~/.yarn-cache`, `.yarn/cache` | Package names and versions |
+| pnpm | `~/.pnpm-store` | Package names and versions |
+| Bun | `~/.bun/install/cache` | Package names and versions |
 
 ## Key Bindings
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,13 @@ impl Default for Config {
             }
         }
 
+        // Bun cache paths
+        for path in probe_bun_paths() {
+            if !roots.contains(&path) {
+                roots.push(path);
+            }
+        }
+
         Self {
             roots,
             sort_by: SortField::Size,
@@ -301,6 +308,40 @@ fn probe_pnpm_paths() -> Vec<PathBuf> {
         if path.exists() && !paths.contains(path) && !is_ancestor_or_descendant(path, &paths) {
             paths.push(path.clone());
         }
+    }
+
+    paths
+}
+
+fn probe_bun_paths() -> Vec<PathBuf> {
+    // Note: Bun does not provide a CLI command to query cache location (unlike
+    // `yarn cache dir` or `pnpm store path`). We rely on env vars and the
+    // default path. If Bun adds such a command, a CLI probe should be added here.
+    let mut paths = Vec::new();
+
+    // Check BUN_INSTALL_CACHE_DIR env var first
+    if let Ok(cache_dir) = std::env::var("BUN_INSTALL_CACHE_DIR") {
+        let path = PathBuf::from(&cache_dir);
+        if path.exists() {
+            paths.push(path);
+            return paths;
+        }
+    }
+
+    // Check BUN_INSTALL env var (cache is at $BUN_INSTALL/install/cache)
+    if let Ok(bun_install) = std::env::var("BUN_INSTALL") {
+        let cache_path = PathBuf::from(&bun_install).join("install/cache");
+        if cache_path.exists() {
+            paths.push(cache_path);
+            return paths;
+        }
+    }
+
+    // Default location
+    let home = dirs_home();
+    let default_cache = home.join(".bun/install/cache");
+    if default_cache.exists() && !paths.contains(&default_cache) {
+        paths.push(default_cache);
     }
 
     paths
@@ -505,6 +546,13 @@ mod tests {
     #[test]
     fn probe_pnpm_cache_handles_missing_tool() {
         let paths = probe_pnpm_paths();
+        let _ = paths;
+    }
+
+    #[test]
+    fn probe_bun_cache_handles_missing_install() {
+        // Bun may not be installed — just verify no panic
+        let paths = probe_bun_paths();
         let _ = paths;
     }
 

--- a/src/providers/bun.rs
+++ b/src/providers/bun.rs
@@ -1,0 +1,360 @@
+use super::{MetadataField, PackageId};
+use std::path::Path;
+
+/// Parse a Bun cache directory path into (package_name, version).
+///
+/// Bun stores packages as `name@version` directories under `~/.bun/install/cache/`.
+/// Scoped packages use real subdirectories: `@scope/name@version`.
+///
+/// Examples:
+/// - `.../lodash@4.17.21` → `("lodash", "4.17.21")`
+/// - `.../react-dom@18.2.0` → `("react-dom", "18.2.0")`
+/// - `.../@babel/core@7.24.0` → `("@babel/core", "7.24.0")`
+/// - `.../@types/node@22.0.0` → `("@types/node", "22.0.0")`
+fn parse_package_from_path(path: &Path) -> Option<(String, String)> {
+    let filename = path.file_name()?.to_str()?;
+
+    // Skip Bun's internal metadata directory
+    if filename == ".cache" {
+        return None;
+    }
+
+    // The filename must contain '@' to separate name from version
+    let at_pos = filename.rfind('@')?;
+    let raw_name = &filename[..at_pos];
+    let version = &filename[at_pos + 1..];
+
+    if raw_name.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    // Version must start with a digit
+    if !version
+        .as_bytes()
+        .first()
+        .is_some_and(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+
+    // Check if parent directory is a scope (starts with '@')
+    let name = if let Some(parent) = path.parent() {
+        if let Some(parent_name) = parent.file_name().and_then(|n| n.to_str()) {
+            if parent_name.starts_with('@') {
+                format!("{parent_name}/{raw_name}")
+            } else {
+                raw_name.to_string()
+            }
+        } else {
+            raw_name.to_string()
+        }
+    } else {
+        raw_name.to_string()
+    };
+
+    Some((name, version.to_string()))
+}
+
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let filename = path.file_name()?.to_str()?;
+
+    match filename {
+        ".bun" => return Some("Bun Runtime".into()),
+        "install" => {
+            if path
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|n| n == ".bun")
+            {
+                return Some("Bun Install Cache".into());
+            }
+        }
+        "cache" => {
+            if path
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|n| n == "install")
+                && path
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .and_then(|p| p.file_name())
+                    .is_some_and(|n| n == ".bun")
+            {
+                return Some("Bun Package Cache".into());
+            }
+        }
+        ".cache" => return Some("Bun Internal Metadata".into()),
+        _ => {}
+    }
+
+    // Scope directories (e.g., @babel, @types) — have a leading '@' but no
+    // second '@' separating name from version.
+    if filename.starts_with('@') && filename.rfind('@') == Some(0) {
+        return None;
+    }
+
+    let (name, version) = parse_package_from_path(path)?;
+    Some(format!("{name} {version}"))
+}
+
+pub fn package_id(path: &Path) -> Option<PackageId> {
+    let (name, version) = parse_package_from_path(path)?;
+    Some(PackageId {
+        ecosystem: "npm",
+        name,
+        version,
+    })
+}
+
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let filename = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    match filename.as_str() {
+        ".bun" | "install" | "cache" => {
+            let count = path.read_dir().map(|d| d.count()).unwrap_or(0);
+            vec![MetadataField {
+                label: "Entries".into(),
+                value: count.to_string(),
+            }]
+        }
+        ".cache" => vec![MetadataField {
+            label: "Type".into(),
+            value: "Bun internal metadata".into(),
+        }],
+        _ => {
+            if filename.starts_with('@') && !filename.contains('/') {
+                // Scope directory (e.g., @babel, @types)
+                let count = path.read_dir().map(|d| d.count()).unwrap_or(0);
+                vec![
+                    MetadataField {
+                        label: "Type".into(),
+                        value: "npm scope".into(),
+                    },
+                    MetadataField {
+                        label: "Packages".into(),
+                        value: count.to_string(),
+                    },
+                ]
+            } else if parse_package_from_path(path).is_some() {
+                vec![MetadataField {
+                    label: "Type".into(),
+                    value: "Cached package".into(),
+                }]
+            } else {
+                vec![]
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- parse_package_from_path ---
+
+    #[test]
+    fn parse_non_scoped_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/lodash@4.17.21");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "lodash");
+        assert_eq!(version, "4.17.21");
+    }
+
+    #[test]
+    fn parse_hyphenated_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/react-dom@18.2.0");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "react-dom");
+        assert_eq!(version, "18.2.0");
+    }
+
+    #[test]
+    fn parse_scoped_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@babel/core@7.24.0");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "@babel/core");
+        assert_eq!(version, "7.24.0");
+    }
+
+    #[test]
+    fn parse_scoped_types_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@types/node@22.0.0");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "@types/node");
+        assert_eq!(version, "22.0.0");
+    }
+
+    #[test]
+    fn parse_rejects_dot_cache() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/.cache");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_no_at_sign() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/just-a-dir");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_empty_version() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/lodash@");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_non_digit_version() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/lodash@latest");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_bare_at_sign() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    // --- semantic_name ---
+
+    #[test]
+    fn semantic_name_bun_root() {
+        let path = PathBuf::from("/home/user/.bun");
+        assert_eq!(semantic_name(&path), Some("Bun Runtime".into()));
+    }
+
+    #[test]
+    fn semantic_name_install_dir() {
+        let path = PathBuf::from("/home/user/.bun/install");
+        assert_eq!(semantic_name(&path), Some("Bun Install Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_cache_dir() {
+        let path = PathBuf::from("/home/user/.bun/install/cache");
+        assert_eq!(semantic_name(&path), Some("Bun Package Cache".into()));
+    }
+
+    #[test]
+    fn semantic_name_internal_metadata() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/.cache");
+        assert_eq!(semantic_name(&path), Some("Bun Internal Metadata".into()));
+    }
+
+    #[test]
+    fn semantic_name_non_scoped_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/express@4.18.2");
+        assert_eq!(semantic_name(&path), Some("express 4.18.2".into()));
+    }
+
+    #[test]
+    fn semantic_name_scoped_package() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@babel/core@7.24.0");
+        assert_eq!(semantic_name(&path), Some("@babel/core 7.24.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_scope_dir_returns_none() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@babel");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    // --- package_id ---
+
+    #[test]
+    fn package_id_non_scoped() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/lodash@4.17.21");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "lodash");
+        assert_eq!(id.version, "4.17.21");
+    }
+
+    #[test]
+    fn package_id_scoped() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/@types/node@22.0.0");
+        let id = package_id(&path).unwrap();
+        assert_eq!(id.ecosystem, "npm");
+        assert_eq!(id.name, "@types/node");
+        assert_eq!(id.version, "22.0.0");
+    }
+
+    #[test]
+    fn package_id_dot_cache_returns_none() {
+        let path = PathBuf::from("/home/user/.bun/install/cache/.cache");
+        assert!(package_id(&path).is_none());
+    }
+
+    #[test]
+    fn package_id_structural_dir_returns_none() {
+        let path = PathBuf::from("/home/user/.bun/install/cache");
+        assert!(package_id(&path).is_none());
+    }
+
+    // =================================================================
+    // Adversarial tests
+    // =================================================================
+
+    #[test]
+    fn parse_multiple_at_signs_uses_last() {
+        // rfind('@') picks the last '@', so name="foo@bar", version="1.0.0"
+        let path = PathBuf::from("/home/user/.bun/install/cache/foo@bar@1.0.0");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "foo@bar");
+        assert_eq!(version, "1.0.0");
+    }
+
+    #[test]
+    fn parse_prerelease_version_accepted() {
+        // Pre-release versions start with a digit, so they pass
+        let path = PathBuf::from("/home/user/.bun/install/cache/pkg@1.0.0-beta.1");
+        let (name, version) = parse_package_from_path(&path).unwrap();
+        assert_eq!(name, "pkg");
+        assert_eq!(version, "1.0.0-beta.1");
+    }
+
+    #[test]
+    fn parse_root_path_returns_none() {
+        let path = PathBuf::from("/");
+        assert!(parse_package_from_path(&path).is_none());
+    }
+
+    #[test]
+    fn parse_path_traversal_normalised_by_file_name() {
+        // file_name() returns just the last component
+        let path = PathBuf::from("/home/user/.bun/install/cache/../../../etc/passwd@1.0.0");
+        let result = parse_package_from_path(&path);
+        // file_name() returns "passwd@1.0.0", which is a valid parse
+        assert!(result.is_some());
+        let (name, version) = result.unwrap();
+        assert_eq!(name, "passwd");
+        assert_eq!(version, "1.0.0");
+    }
+
+    #[test]
+    fn semantic_name_cache_rejects_non_bun_path() {
+        // "cache" dir that is NOT under .bun/install — should NOT match
+        let path = PathBuf::from("/home/user/.bun-tools/install-scripts/cache");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_install_rejects_non_bun_parent() {
+        // "install" dir not under .bun — should NOT match
+        let path = PathBuf::from("/home/user/install");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn metadata_scope_dir_has_type_field() {
+        // Scope directories should have metadata, not empty vec
+        let path = PathBuf::from("/home/user/.bun/install/cache/@babel");
+        let fields = metadata(&path);
+        assert!(!fields.is_empty());
+        assert_eq!(fields[0].value, "npm scope");
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod bun;
 pub mod cargo;
 pub mod chroma;
 pub mod generic;
@@ -68,6 +69,7 @@ pub fn detect(path: &Path) -> CacheKind {
         "torch" => return CacheKind::Torch,
         "chroma" => return CacheKind::Chroma,
         "prisma" => return CacheKind::Prisma,
+        ".bun" => return CacheKind::Bun,
         ".npm" | "npm" => return CacheKind::Npm,
         ".yarn-cache" => return CacheKind::Yarn,
         ".pnpm-store" => return CacheKind::Pnpm,
@@ -111,6 +113,7 @@ pub fn detect(path: &Path) -> CacheKind {
                     return CacheKind::Yarn;
                 }
             }
+            ".bun" => return CacheKind::Bun,
             "huggingface" => return CacheKind::HuggingFace,
             "pip" => return CacheKind::Pip,
             "uv" => return CacheKind::Uv,
@@ -151,6 +154,7 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Prisma => prisma::semantic_name(path),
         CacheKind::Yarn => yarn::semantic_name(path),
         CacheKind::Pnpm => pnpm::semantic_name(path),
+        CacheKind::Bun => bun::semantic_name(path),
         CacheKind::Unknown => None,
     }
 }
@@ -172,6 +176,7 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Prisma => prisma::metadata(path),
         CacheKind::Yarn => yarn::metadata(path),
         CacheKind::Pnpm => pnpm::metadata(path),
+        CacheKind::Bun => bun::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
 }
@@ -191,6 +196,7 @@ pub fn package_id(kind: CacheKind, path: &Path) -> Option<PackageId> {
         CacheKind::Cargo => cargo::package_id(path),
         CacheKind::Yarn => yarn::package_id(path),
         CacheKind::Pnpm => pnpm::package_id(path),
+        CacheKind::Bun => bun::package_id(path),
         _ => None,
     }
 }
@@ -214,6 +220,7 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
         CacheKind::Cargo => Some(format!("cargo update -p {name}")),
         CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
         CacheKind::Pnpm => Some(format!("pnpm add {name}@{version}")),
+        CacheKind::Bun => Some(format!("bun add {name}@{version}")),
         _ => None,
     }
 }
@@ -232,6 +239,19 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
             // Berry project-local caches (.yarn/cache/) may be committed to git (zero-install)
             let path_str = path.to_string_lossy();
             if path_str.contains(".yarn/cache") || path_str.contains(".yarn\\cache") {
+                SafetyLevel::Caution
+            } else {
+                SafetyLevel::Safe
+            }
+        }
+        CacheKind::Bun => {
+            // ~/.bun and ~/.bun/install contain the runtime binary — not safe to delete.
+            // Only the install/cache subtree (package cache) is safe.
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default();
+            if name == ".bun" || name == "install" {
                 SafetyLevel::Caution
             } else {
                 SafetyLevel::Safe
@@ -469,6 +489,13 @@ mod tests {
         assert_eq!(safety(CacheKind::Yarn, &path), SafetyLevel::Safe);
         assert_eq!(
             safety(CacheKind::Pnpm, &PathBuf::from("/home/.pnpm-store/v3")),
+            SafetyLevel::Safe
+        );
+        assert_eq!(
+            safety(
+                CacheKind::Bun,
+                &PathBuf::from("/home/user/.bun/install/cache")
+            ),
             SafetyLevel::Safe
         );
     }
@@ -857,5 +884,117 @@ mod tests {
     #[test]
     fn upgrade_command_pnpm_rejects_injection() {
         assert_eq!(upgrade_command(CacheKind::Pnpm, "$(whoami)", "1.0.0"), None);
+    }
+
+    // --- Bun detection ---
+
+    #[test]
+    fn detect_bun_root() {
+        assert_eq!(detect(&PathBuf::from("/home/user/.bun")), CacheKind::Bun);
+    }
+
+    #[test]
+    fn detect_bun_install_cache() {
+        assert_eq!(
+            detect(&PathBuf::from("/home/user/.bun/install/cache")),
+            CacheKind::Bun
+        );
+    }
+
+    #[test]
+    fn detect_bun_package_subdir() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.bun/install/cache/lodash@4.17.21"
+            )),
+            CacheKind::Bun
+        );
+    }
+
+    #[test]
+    fn detect_bun_scoped_package() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.bun/install/cache/@babel/core@7.24.0"
+            )),
+            CacheKind::Bun
+        );
+    }
+
+    // --- Bun safety ---
+
+    #[test]
+    fn safety_bun_cache_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Bun,
+                &PathBuf::from("/home/user/.bun/install/cache")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_bun_package_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Bun,
+                &PathBuf::from("/home/user/.bun/install/cache/lodash@4.17.21")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_bun_root_is_caution() {
+        assert_eq!(
+            safety(CacheKind::Bun, &PathBuf::from("/home/user/.bun")),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_bun_install_dir_is_caution() {
+        assert_eq!(
+            safety(CacheKind::Bun, &PathBuf::from("/home/user/.bun/install")),
+            SafetyLevel::Caution
+        );
+    }
+
+    // --- Bun upgrade commands ---
+
+    #[test]
+    fn upgrade_command_bun() {
+        assert_eq!(
+            upgrade_command(CacheKind::Bun, "express", "4.18.2"),
+            Some("bun add express@4.18.2".to_string())
+        );
+    }
+
+    #[test]
+    fn upgrade_command_bun_scoped() {
+        assert_eq!(
+            upgrade_command(CacheKind::Bun, "@types/node", "22.0.0"),
+            Some("bun add @types/node@22.0.0".to_string())
+        );
+    }
+
+    // --- Bun detection collisions ---
+
+    #[test]
+    fn detect_npm_inside_bun_cache_is_bun() {
+        // An npm-named package inside the Bun cache — .bun ancestor wins
+        assert_eq!(
+            detect(&PathBuf::from("/home/user/.bun/install/cache/npm@10.0.0")),
+            CacheKind::Bun
+        );
+    }
+
+    #[test]
+    fn upgrade_command_bun_rejects_injection() {
+        assert_eq!(
+            upgrade_command(CacheKind::Bun, "lodash; rm -rf /", "4.17.21"),
+            None
+        );
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -245,16 +245,13 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
             }
         }
         CacheKind::Bun => {
-            // ~/.bun and ~/.bun/install contain the runtime binary — not safe to delete.
-            // Only the install/cache subtree (package cache) is safe.
-            let name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_default();
-            if name == ".bun" || name == "install" {
-                SafetyLevel::Caution
-            } else {
+            // ~/.bun contains the runtime binary, global installs, etc.
+            // Only the install/cache subtree (package cache) is safe to delete.
+            let path_str = path.to_string_lossy();
+            if path_str.contains("install/cache") || path_str.contains("install\\cache") {
                 SafetyLevel::Safe
+            } else {
+                SafetyLevel::Caution
             }
         }
         CacheKind::Unknown => SafetyLevel::Caution,
@@ -957,6 +954,22 @@ mod tests {
     fn safety_bun_install_dir_is_caution() {
         assert_eq!(
             safety(CacheKind::Bun, &PathBuf::from("/home/user/.bun/install")),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_bun_bin_is_caution() {
+        assert_eq!(
+            safety(CacheKind::Bun, &PathBuf::from("/home/user/.bun/bin")),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_bun_bin_binary_is_caution() {
+        assert_eq!(
+            safety(CacheKind::Bun, &PathBuf::from("/home/user/.bun/bin/bun")),
             SafetyLevel::Caution
         );
     }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -17,6 +17,7 @@ pub enum CacheKind {
     Prisma,
     Yarn,
     Pnpm,
+    Bun,
     #[default]
     Unknown,
 }
@@ -38,6 +39,7 @@ impl CacheKind {
             Self::Prisma => "Prisma",
             Self::Yarn => "Yarn",
             Self::Pnpm => "pnpm",
+            Self::Bun => "Bun",
             Self::Unknown => "",
         }
     }
@@ -58,6 +60,7 @@ impl CacheKind {
             Self::Prisma => "Prisma ORM — cached database engine binaries",
             Self::Yarn => "Yarn package manager — cached packages and metadata",
             Self::Pnpm => "pnpm package manager — content-addressed package store",
+            Self::Bun => "Bun runtime — cached npm packages from global install cache",
             Self::Unknown => "",
         }
     }
@@ -78,6 +81,7 @@ impl CacheKind {
             Self::Prisma => "https://www.prisma.io",
             Self::Yarn => "https://yarnpkg.com",
             Self::Pnpm => "https://pnpm.io",
+            Self::Bun => "https://bun.sh",
             Self::Unknown => "",
         }
     }


### PR DESCRIPTION
## Summary

- Add full Bun provider (`src/providers/bun.rs`) with cache detection, semantic naming, package ID extraction, metadata, and upgrade commands
- Vulnerability scanning (OSV.dev) and version checking (npmjs.org) work automatically since Bun uses the npm registry (`ecosystem: "npm"`)
- Safety-aware deletion: `~/.bun` and `~/.bun/install` marked Caution (contain runtime binary), `install/cache` contents marked Safe (re-downloadable)
- Cache root auto-discovery via `BUN_INSTALL_CACHE_DIR`, `BUN_INSTALL` env vars, and `~/.bun/install/cache` fallback
- 22 new tests including adversarial cases for parsing, detection collisions, scope directories, and false-positive rejection

## Test plan

- [x] `cargo test` — 1208 tests pass (22 new)
- [x] `cargo clippy` — zero new warnings
- [x] `cargo fmt` — clean
- [ ] Manual: `ccmd --root ~/.bun/install/cache` shows packages with correct semantic names
- [ ] Manual: `ccmd --root ~/.bun/install/cache --vulncheck` reports vulnerabilities
- [ ] Manual: `ccmd --root ~/.bun/install/cache --versioncheck` reports outdated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)