### PR TITLE
chore: bump rustls-webpki to 0.103.12 (RUSTSEC-2026-0098/0099)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Lockfile-only bump of `rustls-webpki` from 0.103.10 → 0.103.12
- Fixes two RUSTSEC advisories newly published today, both failing the cargo-deny job on every open PR:
  - [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098) — name constraints for URI names incorrectly accepted
  - [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099) — name constraints accepted for wildcard-name certs
- Reachable only after signature verification and requires misissuance to exploit — low practical risk, but fixes CI.
- No `Cargo.toml` change needed; the existing semver range already permits 0.103.12. Transitive dep via `ureq` → `rustls` → `rustls-webpki`.

## Test plan
- [ ] `cargo build` succeeds
- [ ] `cargo deny check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)