### PR TITLE
feat: startup check for newer ccmd releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Startup version check**: when a newer `ccmd` release is available on
+  GitHub, the bottom bar shows `↑ ccmd X.Y.Z available`. The check runs
+  at most once every 24 hours and can be disabled with
+  `--no-update-check`, `CCMD_NO_UPDATE_CHECK=1`, or
+  `[updater] enabled = false` in the config file.
+
 ## [0.2.0] — 2026-04-06
 
 ### Added

--- a/doc/ccmd.1
+++ b/doc/ccmd.1
@@ -10,6 +10,7 @@ ccmd \- browse and manage cache directories
 .RB [ \-\-no\-confirm ]
 .RB [ \-\-vulncheck ]
 .RB [ \-\-versioncheck ]
+.RB [ \-\-no\-update\-check ]
 .PP
 .B ccmd mcp
 .SH DESCRIPTION
@@ -54,6 +55,11 @@ Queries OSV.dev for known vulnerabilities in cached packages.
 .B \-\-versioncheck
 Enable version checking.
 Queries package registries to identify outdated cached packages.
+.TP
+.B \-\-no\-update\-check
+Disable the startup check for newer \fBccmd\fR releases.
+Equivalent to setting \fB[updater] enabled = false\fR in the config file or
+\fBCCMD_NO_UPDATE_CHECK=1\fR in the environment.
 .SH KEYBINDINGS
 .SS Navigation
 .TP
@@ -153,6 +159,9 @@ enabled = false
 
 [versioncheck]
 enabled = false
+
+[updater]
+enabled = true
 .fi
 .RE
 .PP

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,8 @@ pub struct App {
     /// scan requests short-circuit and clear in-progress flags so the UI
     /// doesn't spin on a dead background worker.
     pub scanner_dead: bool,
+    pub update_info: Option<crate::updater::UpdateInfo>,
+    update_rx: mpsc::Receiver<crate::updater::UpdateMsg>,
 }
 
 impl App {
@@ -53,6 +55,7 @@ impl App {
         config: Config,
         scan_rx: mpsc::Receiver<ScanResult>,
         scan_tx: mpsc::Sender<crate::scanner::ScanRequest>,
+        update_rx: mpsc::Receiver<crate::updater::UpdateMsg>,
     ) -> Self {
         let tree = TreeState::new(config.sort_by, config.sort_desc);
         let auto_vuln = config.vulncheck.enabled;
@@ -79,6 +82,8 @@ impl App {
             brew_outdated_in_progress: false,
             auto_brew_outdated_pending: true,
             scanner_dead: false,
+            update_info: None,
+            update_rx,
         }
     }
 
@@ -108,6 +113,15 @@ impl App {
     }
 
     pub fn tick(&mut self) {
+        // Drain any update-check results first — independent of scan pipeline.
+        while let Ok(msg) = self.update_rx.try_recv() {
+            match msg {
+                crate::updater::UpdateMsg::Available(info) => {
+                    self.update_info = Some(info);
+                }
+            }
+        }
+
         // H4: accumulate every status-producing result in this tick, then set
         // `status_msg` once at the end. Previously each arm overwrote the
         // prior message, so a tick draining multiple results only showed the
@@ -871,7 +885,7 @@ impl App {
             String::new()
         };
 
-        let line = if self.mode == AppMode::Filtering {
+        let left_line = if self.mode == AppMode::Filtering {
             Line::from(vec![
                 Span::styled(" /", crate::ui::theme::KEY),
                 Span::styled(&self.filter_text, crate::ui::theme::NORMAL),
@@ -901,9 +915,25 @@ impl App {
             ])
         };
 
-        let bar = Paragraph::new(line)
-            .style(ratatui::style::Style::default().bg(ratatui::style::Color::Rgb(30, 30, 50)));
-        f.render_widget(bar, area);
+        let bg = ratatui::style::Style::default().bg(ratatui::style::Color::Rgb(30, 30, 50));
+
+        let badge_text = self
+            .update_info
+            .as_ref()
+            .map(|i| format!(" ↑ ccmd {} available ", i.latest));
+
+        if let Some(text) = badge_text {
+            let badge_width = text.chars().count() as u16;
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(0), Constraint::Length(badge_width)])
+                .split(area);
+            f.render_widget(Paragraph::new(left_line).style(bg), chunks[0]);
+            let badge_line = Line::from(Span::styled(text, crate::ui::theme::CAUTION));
+            f.render_widget(Paragraph::new(badge_line).style(bg), chunks[1]);
+        } else {
+            f.render_widget(Paragraph::new(left_line).style(bg), area);
+        }
     }
 }
 
@@ -1007,7 +1037,8 @@ mod tests {
     fn build_app(config: Config) -> (App, mpsc::Sender<ScanResult>, mpsc::Receiver<ScanRequest>) {
         let (result_tx, result_rx) = mpsc::channel::<ScanResult>();
         let (scan_tx, scan_rx) = mpsc::channel::<ScanRequest>();
-        let app = App::new(config, result_rx, scan_tx);
+        let (_update_tx, update_rx) = mpsc::channel::<crate::updater::UpdateMsg>();
+        let app = App::new(config, result_rx, scan_tx, update_rx);
         (app, result_tx, scan_rx)
     }
 
@@ -1211,6 +1242,19 @@ mod tests {
         for h in &["navigate", "expand", "mark", "delete", "sort"] {
             assert!(out.contains(h), "missing hint '{h}':\n{out}");
         }
+    }
+
+    #[test]
+    fn draw_bottom_bar_shows_update_badge_when_available() {
+        let (mut app, _tx, _rx) = build_app(bare_config());
+        app.tree.set_roots(vec![mk_node("a", 1, CacheKind::Cargo)]);
+        app.update_info = Some(crate::updater::UpdateInfo {
+            latest: "0.3.1".into(),
+            url: "https://example.com/0.3.1".into(),
+        });
+        let out = render_app(&mut app, 140, 20);
+        assert!(out.contains("↑"), "up arrow:\n{out}");
+        assert!(out.contains("0.3.1"), "version:\n{out}");
     }
 
     // --- tick / ScanResult handling ---------------------------------------
@@ -1636,9 +1680,10 @@ mod tests {
     fn send_scan_request_sets_scanner_dead_on_receiver_drop() {
         let (result_tx, result_rx) = mpsc::channel::<ScanResult>();
         let (scan_tx, scan_rx) = mpsc::channel::<ScanRequest>();
+        let (_update_tx, update_rx) = mpsc::channel::<crate::updater::UpdateMsg>();
         // Drop the scanner-side receiver so the next send fails.
         drop(scan_rx);
-        let mut app = App::new(bare_config(), result_rx, scan_tx);
+        let mut app = App::new(bare_config(), result_rx, scan_tx, update_rx);
         let _ = result_tx; // keep ScanResult tx alive; only scan_rx is dropped
 
         app.vulnscan_in_progress = true;
@@ -1660,8 +1705,9 @@ mod tests {
     fn send_scan_request_is_noop_once_scanner_is_dead() {
         let (result_tx, result_rx) = mpsc::channel::<ScanResult>();
         let (scan_tx, scan_rx) = mpsc::channel::<ScanRequest>();
+        let (_update_tx, update_rx) = mpsc::channel::<crate::updater::UpdateMsg>();
         drop(scan_rx);
-        let mut app = App::new(bare_config(), result_rx, scan_tx);
+        let mut app = App::new(bare_config(), result_rx, scan_tx, update_rx);
         let _ = result_tx;
 
         app.send_scan_request(ScanRequest::ScanVulns(vec![]));

--- a/src/app.rs
+++ b/src/app.rs
@@ -997,6 +997,7 @@ mod tests {
             confirm_delete: true,
             vulncheck: VulncheckConfig::default(),
             versioncheck: VersioncheckConfig::default(),
+            updater: crate::config::UpdaterConfig::default(),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1253,7 +1253,11 @@ mod tests {
             url: "https://example.com/0.3.1".into(),
         });
         let out = render_app(&mut app, 140, 20);
-        assert!(out.contains("↑"), "up arrow:\n{out}");
+        // Assert on the badge-specific label, not just the arrow glyph —
+        // the bottom-bar nav hints already contain `↑↓`, so a bare
+        // `contains("↑")` check would pass even if the badge stopped
+        // rendering entirely (Copilot review on PR #26).
+        assert!(out.contains("available"), "update badge label:\n{out}");
         assert!(out.contains("0.3.1"), "version:\n{out}");
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,9 +215,13 @@ impl Config {
         if cli.no_update_check {
             config.updater.enabled = false;
         }
+        // Only a genuine "yes/1/true/on" disables the updater — a user
+        // typing `CCMD_NO_UPDATE_CHECK=0` should NOT lose update checks
+        // (Copilot review on PR #26).
         if std::env::var("CCMD_NO_UPDATE_CHECK")
-            .map(|v| !v.is_empty())
-            .unwrap_or(false)
+            .ok()
+            .as_deref()
+            .is_some_and(env_flag_is_truthy)
         {
             config.updater.enabled = false;
         }
@@ -428,6 +432,18 @@ fn dirs_home() -> PathBuf {
         })
 }
 
+/// Whether an environment-variable value should be treated as "on" /
+/// "enabled" for boolean-style flags. Matches common conventions
+/// (1/true/yes/on, case-insensitive). Explicitly rejects 0/false/no/off
+/// and the empty string so `CCMD_NO_UPDATE_CHECK=0` doesn't disable
+/// updates by accident.
+fn env_flag_is_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
 fn expand_tilde(path: &Path) -> PathBuf {
     if let Ok(stripped) = path.strip_prefix("~") {
         dirs_home().join(stripped)
@@ -508,6 +524,33 @@ mod tests {
         assert!(!expanded.to_string_lossy().contains('~'));
         // Should be just the home dir
         assert_eq!(expanded, dirs_home());
+    }
+
+    // --- env_flag_is_truthy ---
+
+    #[test]
+    fn env_flag_truthy_values() {
+        for v in ["1", "true", "yes", "on", "TRUE", "Yes", "On", " 1 "] {
+            assert!(env_flag_is_truthy(v), "{v:?} should be truthy");
+        }
+    }
+
+    #[test]
+    fn env_flag_falsy_values() {
+        // Critical: "0" and "false" must NOT be treated as "please disable
+        // updates" — a user typing CCMD_NO_UPDATE_CHECK=0 expects the
+        // update check to stay ENABLED.
+        for v in ["", "0", "false", "no", "off", "FALSE", " "] {
+            assert!(!env_flag_is_truthy(v), "{v:?} should be falsy");
+        }
+    }
+
+    #[test]
+    fn env_flag_unknown_values_are_falsy() {
+        // Conservative: unrecognized strings don't flip the flag.
+        for v in ["maybe", "2", "disable", "enable"] {
+            assert!(!env_flag_is_truthy(v), "{v:?} should be falsy (unknown)");
+        }
     }
 
     // --- Config TOML parsing ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,10 @@ pub struct Cli {
     #[arg(long)]
     pub versioncheck: bool,
 
+    /// Disable the startup check for ccmd updates
+    #[arg(long = "no-update-check")]
+    pub no_update_check: bool,
+
     #[cfg(feature = "mcp")]
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -93,6 +97,18 @@ pub struct VersioncheckConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
+pub struct UpdaterConfig {
+    pub enabled: bool,
+}
+
+impl Default for UpdaterConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub roots: Vec<PathBuf>,
     pub sort_by: SortField,
@@ -100,6 +116,7 @@ pub struct Config {
     pub confirm_delete: bool,
     pub vulncheck: VulncheckConfig,
     pub versioncheck: VersioncheckConfig,
+    pub updater: UpdaterConfig,
 }
 
 impl Default for Config {
@@ -147,6 +164,7 @@ impl Default for Config {
             confirm_delete: true,
             vulncheck: VulncheckConfig::default(),
             versioncheck: VersioncheckConfig::default(),
+            updater: UpdaterConfig::default(),
         }
     }
 }
@@ -168,6 +186,7 @@ impl Config {
             confirm_delete: true,
             vulncheck: VulncheckConfig::default(),
             versioncheck: VersioncheckConfig::default(),
+            updater: UpdaterConfig::default(),
         }
     }
 
@@ -192,6 +211,15 @@ impl Config {
         }
         if cli.versioncheck {
             config.versioncheck.enabled = true;
+        }
+        if cli.no_update_check {
+            config.updater.enabled = false;
+        }
+        if std::env::var("CCMD_NO_UPDATE_CHECK")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
+            config.updater.enabled = false;
         }
 
         // Expand tildes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod scanner;
 pub mod security;
 pub mod tree;
 pub mod ui;
+pub mod updater;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod scanner;
 mod security;
 mod tree;
 mod ui;
+mod updater;
 
 use app::App;
 use config::Config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
 
+    // Background update-check channel
+    let update_rx = updater::start(&config);
+
     // App
-    let mut app = App::new(config, result_rx, scan_tx);
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
     app.init();
 
     // Main loop

--- a/src/updater/cache.rs
+++ b/src/updater/cache.rs
@@ -1,0 +1,1 @@
+// Populated in Task 3.

--- a/src/updater/cache.rs
+++ b/src/updater/cache.rs
@@ -1,1 +1,86 @@
-// Populated in Task 3.
+// `allow(dead_code)` until consumed by `check()` in Task 5.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CacheEntry {
+    pub last_checked: String, // RFC3339
+    pub latest_seen: String,
+    pub html_url: String,
+}
+
+/// Reads the cache file. Returns `None` on any error (missing file,
+/// malformed JSON, permission denied).
+pub fn read_cache(path: &Path) -> Option<CacheEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Writes the cache entry. Best-effort — returns `false` on failure.
+pub fn write_cache(path: &Path, entry: &CacheEntry) -> bool {
+    if let Some(parent) = path.parent()
+        && std::fs::create_dir_all(parent).is_err()
+    {
+        return false;
+    }
+    match serde_json::to_string(entry) {
+        Ok(s) => std::fs::write(path, s).is_ok(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn entry() -> CacheEntry {
+        CacheEntry {
+            last_checked: "2026-04-17T10:00:00Z".into(),
+            latest_seen: "0.3.1".into(),
+            html_url: "https://github.com/juliensimon/cache-commander/releases/tag/v0.3.1".into(),
+        }
+    }
+
+    #[test]
+    fn read_missing_file_returns_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        assert_eq!(read_cache(&path), None);
+    }
+
+    #[test]
+    fn write_then_read_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        let e = entry();
+        assert!(write_cache(&path, &e));
+        assert_eq!(read_cache(&path), Some(e));
+    }
+
+    #[test]
+    fn write_creates_parent_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested/dir/update-check.json");
+        assert!(write_cache(&path, &entry()));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn read_malformed_json_returns_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        std::fs::write(&path, "{not valid json").unwrap();
+        assert_eq!(read_cache(&path), None);
+    }
+
+    #[test]
+    fn read_valid_but_wrong_schema_returns_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("update-check.json");
+        std::fs::write(&path, r#"{"unrelated":"field"}"#).unwrap();
+        assert_eq!(read_cache(&path), None);
+    }
+}

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -1,0 +1,1 @@
+// Populated in Task 4.

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -1,1 +1,63 @@
-// Populated in Task 4.
+// `allow(dead_code)` until consumed by `check()` in Task 5 and `start()` in Task 7.
+#![allow(dead_code)]
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LatestRelease {
+    pub tag_name: String,
+    pub html_url: String,
+}
+
+#[derive(Debug)]
+pub enum UpdaterError {
+    Network,
+    Parse,
+}
+
+pub trait HttpClient {
+    fn get_latest_release(&self) -> Result<LatestRelease, UpdaterError>;
+}
+
+pub struct UreqClient {
+    pub url: String,
+    pub user_agent: String,
+}
+
+impl UreqClient {
+    pub fn for_ccmd() -> Self {
+        Self {
+            url: "https://api.github.com/repos/juliensimon/cache-commander/releases/latest"
+                .to_string(),
+            user_agent: format!("ccmd/{}", env!("CARGO_PKG_VERSION")),
+        }
+    }
+}
+
+impl HttpClient for UreqClient {
+    fn get_latest_release(&self) -> Result<LatestRelease, UpdaterError> {
+        // Mirrors the pattern in `src/security/registry.rs` — `ureq::agent()`
+        // plus a per-request timeout, with User-Agent + Accept headers.
+        let resp = ureq::agent()
+            .get(&self.url)
+            .timeout(std::time::Duration::from_secs(10))
+            .set("User-Agent", &self.user_agent)
+            .set("Accept", "application/vnd.github+json")
+            .call()
+            .map_err(|_| UpdaterError::Network)?;
+        let body = resp.into_string().map_err(|_| UpdaterError::Network)?;
+        serde_json::from_str(&body).map_err(|_| UpdaterError::Parse)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_ccmd_has_expected_url_and_ua() {
+        let c = UreqClient::for_ccmd();
+        assert!(c.url.contains("juliensimon/cache-commander"));
+        assert!(c.user_agent.starts_with("ccmd/"));
+    }
+}

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -53,11 +53,64 @@ impl HttpClient for UreqClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
 
     #[test]
     fn for_ccmd_has_expected_url_and_ua() {
         let c = UreqClient::for_ccmd();
         assert!(c.url.contains("juliensimon/cache-commander"));
         assert!(c.user_agent.starts_with("ccmd/"));
+    }
+
+    /// Spawns a one-shot HTTP server on 127.0.0.1 that returns `body` with
+    /// `Content-Type: application/json` once, then exits. Returns the URL
+    /// the client should hit.
+    fn spawn_one_shot_server(body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                // Drain request bytes so the client's write() doesn't block.
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        format!("http://127.0.0.1:{port}/latest")
+    }
+
+    #[test]
+    fn get_latest_release_parses_github_response() {
+        let url = spawn_one_shot_server(
+            r#"{"tag_name":"v0.3.1","html_url":"https://example.com/v0.3.1","ignored":"field"}"#,
+        );
+        let client = UreqClient {
+            url,
+            user_agent: "ccmd-test/0.0.0".into(),
+        };
+        let release = client.get_latest_release().expect("should succeed");
+        assert_eq!(release.tag_name, "v0.3.1");
+        assert_eq!(release.html_url, "https://example.com/v0.3.1");
+    }
+
+    #[test]
+    fn get_latest_release_returns_parse_error_on_malformed_json() {
+        let url = spawn_one_shot_server("not json");
+        let client = UreqClient {
+            url,
+            user_agent: "ccmd-test/0.0.0".into(),
+        };
+        match client.get_latest_release() {
+            Err(UpdaterError::Parse) => {}
+            other => panic!("expected Parse error, got {other:?}"),
+        }
     }
 }

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -79,11 +79,31 @@ pub fn check(
     }
 }
 
-/// Placeholder — real signature lands in Task 7.
+/// Spawns a background thread that checks GitHub for a newer `ccmd` release.
+/// Returns a receiver that yields at most one `UpdateMsg::Available` if a
+/// newer version exists. Silent on all errors.
 #[allow(dead_code)] // called from main.rs in Task 9
-pub fn start(_config: &crate::config::Config) -> mpsc::Receiver<UpdateMsg> {
-    let (_tx, rx) = mpsc::channel();
+pub fn start(config: &crate::config::Config) -> mpsc::Receiver<UpdateMsg> {
+    let (tx, rx) = mpsc::channel();
+    if !config.updater.enabled {
+        return rx;
+    }
+    std::thread::spawn(move || {
+        let cache_path = match cache_file_path() {
+            Some(p) => p,
+            None => return,
+        };
+        let http = http::UreqClient::for_ccmd();
+        if let Some(info) = check(env!("CARGO_PKG_VERSION"), &cache_path, &http, Utc::now()) {
+            let _ = tx.send(UpdateMsg::Available(info));
+        }
+    });
     rx
+}
+
+fn cache_file_path() -> Option<std::path::PathBuf> {
+    let proj = directories::ProjectDirs::from("", "", "ccmd")?;
+    Some(proj.cache_dir().join("update-check.json"))
 }
 
 #[cfg(test)]

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -1,0 +1,25 @@
+pub mod cache;
+pub mod http;
+pub mod version;
+
+use std::sync::mpsc;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // fields consumed once `check` is implemented (Task 5)
+pub struct UpdateInfo {
+    pub latest: String,
+    pub url: String,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)] // variant constructed in Task 5, matched on in Task 8
+pub enum UpdateMsg {
+    Available(UpdateInfo),
+}
+
+/// Placeholder — real signature lands in Task 7.
+#[allow(dead_code)] // called from main.rs in Task 9
+pub fn start(_config: &crate::config::Config) -> mpsc::Receiver<UpdateMsg> {
+    let (_tx, rx) = mpsc::channel();
+    rx
+}

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -94,11 +94,30 @@ pub fn start(config: &crate::config::Config) -> mpsc::Receiver<UpdateMsg> {
             None => return,
         };
         let http = http::UreqClient::for_ccmd();
-        if let Some(info) = check(env!("CARGO_PKG_VERSION"), &cache_path, &http, Utc::now()) {
-            let _ = tx.send(UpdateMsg::Available(info));
-        }
+        run_check_and_send(
+            &tx,
+            env!("CARGO_PKG_VERSION"),
+            &cache_path,
+            &http,
+            Utc::now(),
+        );
     });
     rx
+}
+
+/// Runs `check` and, if an update is available, forwards it on the channel.
+/// Extracted from the closure in `start` so tests can drive it with a fake
+/// `HttpClient` without spawning a thread or hitting the real clock.
+fn run_check_and_send(
+    tx: &mpsc::Sender<UpdateMsg>,
+    current: &str,
+    cache_path: &Path,
+    http: &dyn HttpClient,
+    now: DateTime<Utc>,
+) {
+    if let Some(info) = check(current, cache_path, http, now) {
+        let _ = tx.send(UpdateMsg::Available(info));
+    }
 }
 
 fn cache_file_path() -> Option<std::path::PathBuf> {
@@ -238,5 +257,69 @@ mod tests {
         let entry = cache::read_cache(&path).expect("cache written");
         assert_eq!(entry.latest_seen, "0.3.1");
         assert_eq!(entry.last_checked, now().to_rfc3339());
+    }
+
+    #[test]
+    fn fresh_cache_hit_with_equal_version_returns_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        cache::write_cache(
+            &path,
+            &CacheEntry {
+                last_checked: now().to_rfc3339(),
+                latest_seen: "0.3.0".into(),
+                html_url: "https://example.com/0.3.0".into(),
+            },
+        );
+        let http = FakeClient::ok("v9.9.9");
+        assert_eq!(check("0.3.0", &path, &http, now()), None);
+        assert_eq!(http.calls.get(), 0, "cache hit must skip HTTP");
+    }
+
+    #[test]
+    fn run_check_and_send_forwards_available_update() {
+        let (tx, rx) = mpsc::channel();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.1");
+        run_check_and_send(&tx, "0.3.0", &path, &http, now());
+        match rx.try_recv() {
+            Ok(UpdateMsg::Available(info)) => assert_eq!(info.latest, "0.3.1"),
+            other => panic!("expected Available, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_check_and_send_sends_nothing_when_up_to_date() {
+        let (tx, rx) = mpsc::channel();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.0");
+        run_check_and_send(&tx, "0.3.0", &path, &http, now());
+        assert!(rx.try_recv().is_err(), "no message should be sent");
+    }
+
+    #[test]
+    fn start_returns_empty_receiver_when_disabled() {
+        let mut config = crate::config::Config::default_for_test();
+        config.updater.enabled = false;
+        let rx = start(&config);
+        assert!(
+            rx.try_recv().is_err(),
+            "disabled updater must not produce messages"
+        );
+    }
+
+    #[test]
+    fn cache_file_path_is_under_ccmd_dir() {
+        let path = cache_file_path().expect("ProjectDirs should resolve on test hosts");
+        assert!(path.ends_with("update-check.json"));
+        // Sanity: the parent directory should mention "ccmd" somewhere in its
+        // path (e.g. ~/Library/Caches/ccmd on macOS or ~/.cache/ccmd on Linux).
+        let parent_str = path.parent().unwrap().to_string_lossy().to_lowercase();
+        assert!(
+            parent_str.contains("ccmd"),
+            "unexpected cache dir: {parent_str}"
+        );
     }
 }

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -2,19 +2,81 @@ pub mod cache;
 pub mod http;
 pub mod version;
 
+use chrono::{DateTime, Utc};
+use std::path::Path;
 use std::sync::mpsc;
 
+use http::HttpClient;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // fields consumed once `check` is implemented (Task 5)
+#[allow(dead_code)] // fields consumed by `App` render code in Task 8
 pub struct UpdateInfo {
     pub latest: String,
     pub url: String,
 }
 
 #[derive(Debug)]
-#[allow(dead_code)] // variant constructed in Task 5, matched on in Task 8
+#[allow(dead_code)] // variant matched on in Task 8
 pub enum UpdateMsg {
     Available(UpdateInfo),
+}
+
+pub const CACHE_TTL_HOURS: i64 = 24;
+
+/// Pure orchestration: given a current version, a cache file path, an HTTP
+/// client, and a clock, return `Some(UpdateInfo)` iff a strictly-newer
+/// non-pre-release upgrade is available. Silent on all errors.
+#[allow(dead_code)] // wired into `start()` in Task 7
+pub fn check(
+    current: &str,
+    cache_path: &Path,
+    http: &dyn HttpClient,
+    now: DateTime<Utc>,
+) -> Option<UpdateInfo> {
+    if version::is_prerelease(current) {
+        return None;
+    }
+
+    if let Some(entry) = cache::read_cache(cache_path)
+        && let Ok(last) = DateTime::parse_from_rfc3339(&entry.last_checked)
+        && (now - last.with_timezone(&Utc)) < chrono::Duration::hours(CACHE_TTL_HOURS)
+    {
+        return if version::is_newer(current, &entry.latest_seen) {
+            Some(UpdateInfo {
+                latest: entry.latest_seen,
+                url: entry.html_url,
+            })
+        } else {
+            None
+        };
+    }
+
+    let fetched = match http.get_latest_release() {
+        Ok(r) => r,
+        Err(_) => return None,
+    };
+
+    let tag = fetched
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&fetched.tag_name);
+    let _ = cache::write_cache(
+        cache_path,
+        &cache::CacheEntry {
+            last_checked: now.to_rfc3339(),
+            latest_seen: tag.to_string(),
+            html_url: fetched.html_url.clone(),
+        },
+    );
+
+    if version::is_newer(current, tag) {
+        Some(UpdateInfo {
+            latest: tag.to_string(),
+            url: fetched.html_url,
+        })
+    } else {
+        None
+    }
 }
 
 /// Placeholder — real signature lands in Task 7.
@@ -22,4 +84,139 @@ pub enum UpdateMsg {
 pub fn start(_config: &crate::config::Config) -> mpsc::Receiver<UpdateMsg> {
     let (_tx, rx) = mpsc::channel();
     rx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cache::CacheEntry;
+    use chrono::Duration;
+    use http::{LatestRelease, UpdaterError};
+    use std::cell::Cell;
+    use tempfile::tempdir;
+
+    struct FakeClient {
+        response: Result<LatestRelease, UpdaterError>,
+        calls: Cell<usize>,
+    }
+
+    impl FakeClient {
+        fn ok(tag: &str) -> Self {
+            Self {
+                response: Ok(LatestRelease {
+                    tag_name: tag.to_string(),
+                    html_url: format!(
+                        "https://github.com/juliensimon/cache-commander/releases/tag/{tag}"
+                    ),
+                }),
+                calls: Cell::new(0),
+            }
+        }
+        fn err() -> Self {
+            Self {
+                response: Err(UpdaterError::Network),
+                calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl HttpClient for FakeClient {
+        fn get_latest_release(&self) -> Result<LatestRelease, UpdaterError> {
+            self.calls.set(self.calls.get() + 1);
+            match &self.response {
+                Ok(r) => Ok(r.clone()),
+                Err(_) => Err(UpdaterError::Network),
+            }
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-04-17T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn returns_info_when_remote_is_newer() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.1");
+        let info = check("0.3.0", &path, &http, now());
+        assert_eq!(info.as_ref().map(|i| i.latest.as_str()), Some("0.3.1"));
+        assert!(info.unwrap().url.contains("v0.3.1"));
+        assert_eq!(http.calls.get(), 1);
+    }
+
+    #[test]
+    fn returns_none_when_up_to_date() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.0");
+        assert_eq!(check("0.3.0", &path, &http, now()), None);
+    }
+
+    #[test]
+    fn returns_none_on_network_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::err();
+        assert_eq!(check("0.3.0", &path, &http, now()), None);
+    }
+
+    #[test]
+    fn returns_none_when_current_is_prerelease() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.0");
+        assert_eq!(check("0.4.0-dev", &path, &http, now()), None);
+        assert_eq!(http.calls.get(), 0, "must not call HTTP for pre-release");
+    }
+
+    #[test]
+    fn fresh_cache_hit_skips_http_call() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        cache::write_cache(
+            &path,
+            &CacheEntry {
+                last_checked: now().to_rfc3339(),
+                latest_seen: "0.3.1".into(),
+                html_url: "https://example.com/0.3.1".into(),
+            },
+        );
+        let http = FakeClient::ok("v9.9.9");
+        let info = check("0.3.0", &path, &http, now());
+        assert_eq!(info.unwrap().latest, "0.3.1");
+        assert_eq!(http.calls.get(), 0, "cache hit must skip HTTP");
+    }
+
+    #[test]
+    fn stale_cache_triggers_refresh() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let old = now() - Duration::hours(25);
+        cache::write_cache(
+            &path,
+            &CacheEntry {
+                last_checked: old.to_rfc3339(),
+                latest_seen: "0.3.1".into(),
+                html_url: "https://example.com/0.3.1".into(),
+            },
+        );
+        let http = FakeClient::ok("v0.3.2");
+        let info = check("0.3.0", &path, &http, now());
+        assert_eq!(info.unwrap().latest, "0.3.2");
+        assert_eq!(http.calls.get(), 1);
+    }
+
+    #[test]
+    fn http_call_updates_cache() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("c.json");
+        let http = FakeClient::ok("v0.3.1");
+        let _ = check("0.3.0", &path, &http, now());
+        let entry = cache::read_cache(&path).expect("cache written");
+        assert_eq!(entry.latest_seen, "0.3.1");
+        assert_eq!(entry.last_checked, now().to_rfc3339());
+    }
 }

--- a/src/updater/version.rs
+++ b/src/updater/version.rs
@@ -1,0 +1,1 @@
+// Populated in Task 2.

--- a/src/updater/version.rs
+++ b/src/updater/version.rs
@@ -1,1 +1,110 @@
-// Populated in Task 2.
+// `allow(dead_code)` until consumed by `check()` in Task 5.
+#![allow(dead_code)]
+
+/// Parses a version string like `v0.3.0`, `0.3.0`, or `0.3.0-dev`.
+/// Returns `None` for unparseable input. Pre-release and build metadata
+/// are stripped before parsing.
+pub fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    let s = s.strip_prefix('v').unwrap_or(s);
+    let core = s.split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// True iff `current` is a pre-release (contains `-` after the version core).
+pub fn is_prerelease(current: &str) -> bool {
+    let s = current.strip_prefix('v').unwrap_or(current);
+    s.contains('-')
+}
+
+/// True iff `latest` is strictly newer than `current` AND `current` is not
+/// a pre-release. Returns false on any parse failure.
+pub fn is_newer(current: &str, latest: &str) -> bool {
+    if is_prerelease(current) {
+        return false;
+    }
+    match (parse_semver(current), parse_semver(latest)) {
+        (Some(c), Some(l)) => l > c,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_plain() {
+        assert_eq!(parse_semver("0.3.0"), Some((0, 3, 0)));
+    }
+
+    #[test]
+    fn parse_with_v_prefix() {
+        assert_eq!(parse_semver("v1.2.3"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn parse_strips_prerelease() {
+        assert_eq!(parse_semver("0.3.0-dev"), Some((0, 3, 0)));
+        assert_eq!(parse_semver("v0.3.0-rc.1"), Some((0, 3, 0)));
+    }
+
+    #[test]
+    fn parse_strips_build_metadata() {
+        assert_eq!(parse_semver("0.3.0+build.5"), Some((0, 3, 0)));
+    }
+
+    #[test]
+    fn parse_rejects_garbage() {
+        assert_eq!(parse_semver(""), None);
+        assert_eq!(parse_semver("abc"), None);
+        assert_eq!(parse_semver("1.2"), None);
+        assert_eq!(parse_semver("1.2.x"), None);
+    }
+
+    #[test]
+    fn is_prerelease_detects_dash() {
+        assert!(is_prerelease("0.3.0-dev"));
+        assert!(is_prerelease("v0.3.0-rc.1"));
+    }
+
+    #[test]
+    fn is_prerelease_false_for_plain() {
+        assert!(!is_prerelease("0.3.0"));
+        assert!(!is_prerelease("v1.2.3"));
+    }
+
+    #[test]
+    fn is_newer_strictly_greater() {
+        assert!(is_newer("0.3.0", "0.3.1"));
+        assert!(is_newer("0.3.0", "0.4.0"));
+        assert!(is_newer("0.3.0", "1.0.0"));
+        assert!(is_newer("0.3.0", "v0.3.1"));
+    }
+
+    #[test]
+    fn is_newer_false_when_equal_or_older() {
+        assert!(!is_newer("0.3.1", "0.3.0"));
+        assert!(!is_newer("0.3.0", "0.3.0"));
+        assert!(!is_newer("1.0.0", "0.9.9"));
+    }
+
+    #[test]
+    fn is_newer_suppresses_for_prerelease_current() {
+        assert!(!is_newer("0.4.0-dev", "0.3.0"));
+        assert!(!is_newer("0.4.0-dev", "0.4.0"));
+        assert!(!is_newer("0.4.0-dev", "0.5.0"));
+    }
+
+    #[test]
+    fn is_newer_false_on_parse_failure() {
+        assert!(!is_newer("garbage", "0.3.0"));
+        assert!(!is_newer("0.3.0", "garbage"));
+    }
+}

--- a/src/updater/version.rs
+++ b/src/updater/version.rs
@@ -69,6 +69,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_rejects_too_many_components() {
+        assert_eq!(parse_semver("1.2.3.4"), None);
+        assert_eq!(parse_semver("v1.2.3.4"), None);
+    }
+
+    #[test]
     fn is_prerelease_detects_dash() {
         assert!(is_prerelease("0.3.0-dev"));
         assert!(is_prerelease("v0.3.0-rc.1"));

--- a/tests/keybindings.rs
+++ b/tests/keybindings.rs
@@ -74,7 +74,8 @@ fn test_app() -> App {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     // Set up a tree with roots and children
     app.tree.set_roots(vec![
@@ -258,7 +259,8 @@ fn key_d_without_confirm_deletes_immediately() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![TreeNode {
         path: dir.clone(),
@@ -310,7 +312,8 @@ fn delete_mode_y_confirms() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![TreeNode {
         path: dir.clone(),
@@ -392,7 +395,8 @@ fn bulk_delete_multiple_marked_items() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![
         TreeNode {
@@ -467,7 +471,8 @@ fn bulk_delete_with_confirm_dialog() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![
         TreeNode {
@@ -531,7 +536,8 @@ fn delete_uses_paths_not_stale_indices() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![
         TreeNode {
@@ -896,7 +902,8 @@ fn vuln_propagates_to_ancestors() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     let parent_path = PathBuf::from("/cache/uv");
     let child_path = PathBuf::from("/cache/uv/archive/pkg1");
@@ -942,7 +949,8 @@ fn outdated_propagates_to_ancestors() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     let parent_path = PathBuf::from("/cache/uv");
     let child_path = PathBuf::from("/cache/uv/archive/pkg1");
@@ -1186,7 +1194,8 @@ fn full_workflow_filter_mark_delete() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![
         TreeNode {
@@ -1632,7 +1641,8 @@ fn delete_while_filter_recomputes_dimmed() {
     };
     let (result_tx, result_rx) = mpsc::channel();
     let scan_tx = scanner::start(result_tx);
-    let mut app = App::new(config, result_rx, scan_tx);
+    let (_update_tx, update_rx) = mpsc::channel::<ccmd::updater::UpdateMsg>();
+    let mut app = App::new(config, result_rx, scan_tx, update_rx);
 
     app.tree.set_roots(vec![
         TreeNode {


### PR DESCRIPTION
## Summary

- Adds a non-intrusive startup check against GitHub Releases. When a newer `ccmd` is published, the bottom bar shows `↑ ccmd X.Y.Z available` (right-aligned, rendered in the existing `CAUTION` theme color).
- Runs on a fire-and-forget background thread — zero impact on TUI startup. Results caches at `<cache-dir>/update-check.json` for 24h so repeated launches don't hit GitHub's rate limit.
- Three opt-out paths, priority CLI > env > config: `--no-update-check`, `CCMD_NO_UPDATE_CHECK=1`, `[updater] enabled = false`. On-by-default otherwise.
- Pre-release builds (version contains `-`, e.g. `0.4.0-dev`) never show the badge, to avoid `0.4.0-dev > 0.3.0` false positives.

## Architecture

- New `src/updater/` module: `version.rs` (parse/compare), `cache.rs` (JSON round-trip), `http.rs` (trait + `UreqClient`), `mod.rs` (pure `check()` orchestrator + `start()` thread spawn).
- `check()` is dependency-injected over `HttpClient` and `DateTime<Utc>` — all seven orchestrator tests run without network or system clock.
- `App` drains the update receiver alongside scanner results; render is right-aligned via a horizontal `Layout` split in `render_bottom_bar`.

## Design & plan

- Spec: `docs/superpowers/specs/2026-04-17-startup-version-check-design.md` (gitignored)
- Plan: `docs/superpowers/plans/2026-04-17-startup-version-check.md` (gitignored)

## Test Plan

- [x] `cargo test` — 1579 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] CLI: `ccmd --help` lists `--no-update-check`
- [x] Manual: launch TUI, confirm no badge when up-to-date
- [ ] Manual: temporarily set `Cargo.toml` version to `0.0.1`, delete cache file, confirm `↑ ccmd X.Y.Z available` appears
- [ ] Manual: with temp low version, confirm `--no-update-check` and `CCMD_NO_UPDATE_CHECK=1` suppress badge
- [ ] Manual: with network disabled, confirm TUI opens instantly, no badge, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)