### PR TITLE
Add SwiftPM and Xcode providers (#11, #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 ## [Unreleased]
 
 ### Added
+- **SwiftPM provider (#11)**: detects `~/Library/Caches/org.swift.swiftpm`
+  (macOS) and `~/.cache/org.swift.swiftpm` (Linux). Classifies
+  `repositories/` as Caution (re-clone cost on rebuild) and
+  `artifacts/`/`manifests/` as Safe. Repository directories render with
+  the trailing git-URL hash stripped (e.g. `swift-collections-abc1234`
+  → `swift-collections`). **No OSV or version-check**: package identity
+  in SwiftPM's `repositories/` requires git-ref parsing that is too
+  brittle for v1, and OSV's `SwiftURL` coverage is sparse. Pressing `c`
+  on a SwiftPM entry is a no-op by design — Swift package upgrades are
+  project-local (`Package.swift` / `Package.resolved`), not global.
+- **Xcode provider (#17)**: detects `~/Library/Developer/Xcode/DerivedData`,
+  `~/Library/Developer/Xcode/iOS DeviceSupport`, and
+  `~/Library/Developer/CoreSimulator/Caches` — often the single largest
+  caches on macOS dev machines (DerivedData alone is routinely 50–200 GB).
+  DerivedData is classified as Caution (rebuild takes 5–30 min); the
+  other two are Safe. DerivedData project directories show the original
+  workspace path (extracted from `Info.plist` `WORKSPACE_PATH`) in the
+  detail panel so you can confirm which project you're about to delete.
+  **No OSV, no version-check, no upgrade command** — these are build
+  artifacts, not packages.
 - **Maven / Gradle upgrade snippets**: pressing `c` on a Maven or Gradle
   artifact now copies a paste-ready snippet to the clipboard — a
   `<dependency>…</dependency>` block for Maven, an `implementation

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Developer machines accumulate tens of gigabytes of invisible cache data — ML m
 ## Why
 
 - **ML models** (HuggingFace, PyTorch, Whisper) — tens of GB you forgot about
-- **Package caches** (pip, uv, npm, Yarn, pnpm, Bun, Cargo, Maven, Gradle, Homebrew) — old versions with known CVEs
+- **Package caches** (pip, uv, npm, Yarn, pnpm, Bun, Cargo, Maven, Gradle, SwiftPM, Homebrew) — old versions with known CVEs
+- **Xcode DerivedData** — often 50–200 GB on macOS dev machines; never cleaned
 - **npm supply chain risk** — transitive deps with install scripts hiding in npx cache
 - **Build artifacts** (pre-commit hooks, Prisma engines) — stale and re-downloadable
 
@@ -77,7 +78,7 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 ### Browse and Understand
 
 - **Two-pane TUI** — navigable tree on the left, details on the right
-- **17 cache providers** — semantic names instead of hash directories
+- **19 cache providers** — semantic names instead of hash directories
 - **Safety levels** — green (safe to delete), yellow (may cause rebuilds), red (contains state)
 - **Sort** by size, name, or last modified
 - **Search** with `/` — case-insensitive filter across the tree
@@ -122,6 +123,8 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 | Bun | `~/.bun/install/cache` | Package names and versions |
 | Maven | `~/.m2/repository` | `group:artifact version` from layout |
 | Gradle | `~/.gradle/caches` | `group:artifact version` from `files-2.1` layout |
+| SwiftPM | `~/Library/Caches/org.swift.swiftpm` (macOS), `~/.cache/org.swift.swiftpm` (Linux) | Package names from `repositories/` and `artifacts/` |
+| Xcode | `~/Library/Developer/Xcode/DerivedData`, `~/Library/Developer/Xcode/iOS DeviceSupport`, `~/Library/Developer/CoreSimulator/Caches` | Workspace path from `Info.plist`, iOS version strings |
 
 ## Key Bindings
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,42 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 | SwiftPM | `~/Library/Caches/org.swift.swiftpm` (macOS), `~/.cache/org.swift.swiftpm` (Linux) | Package names from `repositories/` and `artifacts/` |
 | Xcode | `~/Library/Developer/Xcode/DerivedData`, `~/Library/Developer/Xcode/iOS DeviceSupport`, `~/Library/Developer/CoreSimulator/Caches` | Workspace path from `Info.plist`, iOS version strings |
 
+## Provider Capabilities
+
+All providers support tree navigation, size display, and deletion. This matrix shows which optional capabilities each provider implements.
+
+| Provider | Safety classification | Vuln scan (`v`/`V`) | Outdated check (`o`/`O`) | Upgrade copy (`c`) |
+|----------|----------------------|---------------------|--------------------------|--------------------|
+| HuggingFace | Safe | — | — | — |
+| pip | Safe | OSV `PyPI` | PyPI | `pip install` |
+| uv | Safe | OSV `PyPI` | PyPI | `uv pip install` |
+| npm | Safe | OSV `npm` | npm registry | `npm install` |
+| Homebrew | Safe | — | — | — |
+| Cargo | Safe | OSV `crates.io` | crates.io | `cargo update -p` |
+| pre-commit | Safe | — | — | — |
+| Whisper | Safe | — | — | — |
+| GitHub CLI | Safe | — | — | — |
+| PyTorch | Safe | — | — | — |
+| Chroma | Safe | — | — | — |
+| Prisma | Safe | — | — | — |
+| Yarn | Safe; Berry `.yarn/cache/` = **Caution** (zero-install) | OSV `npm` | npm registry | `yarn add` |
+| pnpm | Safe; virtual store (`node_modules/.pnpm/`) = **Caution** | OSV `npm` | npm registry | `pnpm add` |
+| Bun | Safe for `install/cache/`; `.bun/bin/*` = **Unsafe** (runtime); else **Caution** | OSV `npm` | npm registry | `bun add` |
+| Maven | Safe | OSV `Maven` | Maven Central | `<dependency>…</dependency>` snippet |
+| Gradle | Safe; `build-cache-*/` + `transforms-*/` = **Caution** | OSV `Maven` | Maven Central | `implementation '…'` line |
+| SwiftPM | `repositories/` = **Caution** (re-clone); `artifacts/` + `manifests/` = Safe; unknown subdirs = **Caution** | — ¹ | — ¹ | — ¹ |
+| Xcode | `DerivedData/` = **Caution** (5–30 min rebuild); `iOS DeviceSupport/` + `CoreSimulator/Caches/` = Safe | — ² | — ² | — ² |
+
+Legend:
+- **Safe** = re-downloadable, free to delete (shown with `●` in the detail panel).
+- **Caution** = deletion triggers rebuild / re-fetch cost (shown with `◐`).
+- **Unsafe** = deletion breaks the tool itself (shown with `○`).
+- **—** = not supported for this provider.
+
+Notes:
+- ¹ **SwiftPM** is intentionally disk-hygiene only in v1. Swift package identity in the on-disk `repositories/` layout requires parsing git refs, which is too brittle; OSV's `SwiftURL` ecosystem has sparse coverage; and Swift package upgrades are project-local (`Package.swift` / `Package.resolved`), not global cache operations. May be reconsidered when OSV coverage improves.
+- ² **Xcode** has no package-manager ecosystem — its caches are build artifacts, not packages. Vulnerability scanning, version checking, and upgrade commands don't apply.
+
 ## Key Bindings
 
 ### Navigation

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,93 @@
+# TODO — Cache Commander (ccmd)
+
+## New Providers
+
+- [ ] **Yarn** — `~/.cache/yarn`, Berry PnP cache (`#1`)
+- [ ] **pnpm** — `~/.local/share/pnpm/store` (`#1`)
+- [ ] **Go modules** — `~/go/pkg/mod`, `~/go/pkg/mod/cache`
+- [ ] **Conda / Mamba** — `~/anaconda3/pkgs`, `~/.conda/pkgs`, `~/miniforge3/pkgs`
+- [ ] **Docker** — `~/Library/Containers/com.docker.docker/Data/vms` (macOS), `/var/lib/docker` (Linux), BuildKit cache
+- [ ] **Maven** — `~/.m2/repository`
+- [ ] **Gradle** — `~/.gradle/caches`, `~/.gradle/wrapper/dists`
+- [ ] **CocoaPods** — `~/Library/Caches/CocoaPods`
+- [ ] **Xcode DerivedData** — `~/Library/Developer/Xcode/DerivedData`
+- [ ] **Swift Package Manager** — `~/Library/Caches/org.swift.swiftpm`
+- [ ] **Composer** (PHP) — `~/.cache/composer`, `~/.composer/cache`
+- [ ] **Ruby gems** — `~/.gem`, `~/.bundle/cache`
+- [ ] **Bazel** — `~/.cache/bazel`
+- [ ] **ccache / sccache** — `~/.cache/ccache`, `~/.cache/sccache`
+- [ ] **Nix** — `~/.cache/nix`
+
+## Cache Analysis
+
+- [ ] **Stale cache detection** — flag caches not accessed in N days (configurable threshold, e.g. 90 days)
+- [ ] **Duplicate detection** — find identical files across providers (content-hash based)
+- [ ] **Disk usage trends** — store periodic snapshots in `~/.config/ccmd/history.json`, show sparkline in TUI
+- [ ] **Space reclaim estimate** — "you could free X GB" summary for stale + vulnerable + outdated items
+- [ ] **Per-project usage** — link cached packages back to projects that use them (scan Cargo.lock, package-lock.json, etc.)
+- [ ] **License scanning** — identify licenses of cached packages (SPDX from registry metadata)
+
+## Cleanup Automation
+
+- [ ] **Cleanup policies** — TOML rules: `max_age = "90d"`, `max_size = "10GB"`, per-provider overrides
+- [ ] **Dry-run mode** — `ccmd clean --dry-run` to preview what policies would delete
+- [ ] **Scheduled cleanup** — `ccmd clean --schedule` via launchd (macOS) or systemd timer (Linux)
+- [ ] **Pin/protect** — mark specific caches as protected (never auto-delete)
+- [ ] **Undo / trash** — move to trash instead of permanent delete, with `ccmd restore` to recover
+
+## TUI Enhancements
+
+- [ ] **Regex search** — extend `/` filter to support regex patterns
+- [ ] **Mark by pattern** — `M` to mark all items matching a glob/regex
+- [ ] **Bulk mark outdated** — one-key mark all outdated or vulnerable items for deletion
+- [ ] **Size bar visualization** — proportional size bars in tree panel (like `dust`)
+- [ ] **Multi-column sort** — secondary sort key (e.g. sort by provider then size)
+- [ ] **Treemap view** — alternate visualization showing cache usage as nested rectangles
+- [ ] **Mouse support** — click to select, scroll, expand/collapse
+
+## CLI / Non-Interactive
+
+- [ ] **JSON output** — `ccmd --json` for scripting and piping
+- [ ] **CSV export** — `ccmd export --format csv` for spreadsheet analysis
+- [ ] **One-shot commands** — `ccmd scan --vulns`, `ccmd scan --outdated`, `ccmd clean --stale 90d` without TUI
+- [ ] **Shell completions** — generate completions for bash, zsh, fish via clap
+- [ ] **Exit codes** — meaningful exit codes for CI (e.g. non-zero if vulns found)
+
+## Security Improvements
+
+- [ ] **SBOM generation** — export cached packages as CycloneDX or SPDX SBOM
+- [ ] **Severity filtering** — filter vulns by CVSS score threshold (e.g. only critical/high)
+- [ ] **Auto-remediation** — option to run upgrade commands directly from ccmd
+- [ ] **Vulnerability alerting** — notify when new CVEs affect cached packages (via MCP or webhook)
+- [ ] **Install script auditing** — expand npm install-script detection to show script contents
+
+## MCP Server
+
+- [ ] **Watch mode** — MCP resource subscriptions for real-time cache change notifications
+- [ ] **Cleanup policy management** — CRUD policies via MCP tools
+- [ ] **History queries** — "how much cache did I clean this week?" via MCP
+- [ ] **Batch operations** — delete all outdated/vulnerable in one MCP call
+
+## Windows Support
+
+- [ ] **Add `windows-latest` to CI test matrix** — catch compile errors and test failures early
+- [ ] **Default cache roots** — add `%LOCALAPPDATA%` via `BaseDirs::cache_dir()` in `config.rs`
+- [ ] **Per-provider Windows paths** — npm (`%AppData%/npm-cache`), pip (`%LOCALAPPDATA%/pip/Cache`), Cargo (`%USERPROFILE%\.cargo\registry`), uv, Go, etc.
+- [ ] **Clipboard** — add `clip.exe` branch in `copy_to_clipboard()` (`app.rs`)
+- [ ] **Guard unix-only code** — `#[cfg(unix)]` on symlink tests in `huggingface.rs` and `mcp/mod.rs`
+- [ ] **Scheduled cleanup** — add Windows Task Scheduler support alongside launchd/systemd
+- [ ] **Release binaries** — add `x86_64-pc-windows-msvc` target to `release.yml`, produce `.exe`
+- [ ] **Windows installer** — optional `.msi` via `cargo-wix`
+- [ ] **TUI smoke test** — verify rendering on Windows Terminal / ConPTY (needs a Windows tester)
+
+## Code Quality (from REVIEW-0.2.0.md)
+
+- [ ] Wire up `SafetyLevel::Unsafe` or remove dead code (M5)
+- [ ] Handle `scan_tx.send()` failures instead of `let _ =` (M2)
+- [ ] Fix status message overwriting on rapid scan completion (M3)
+- [ ] Fix UTF-8 unsafe byte-level parsing in homebrew.rs (M4)
+- [ ] Enable clippy pedantic lints in CI (M6)
+- [ ] Add mocked HTTP tests for OSV and registry APIs
+- [ ] Add tests for `perform_delete` error paths
+- [ ] Add tests for scanner threading behavior
+- [ ] Add MSRV enforcement in CI

--- a/TODO.md
+++ b/TODO.md
@@ -10,8 +10,8 @@
 - [ ] **Maven** — `~/.m2/repository`
 - [ ] **Gradle** — `~/.gradle/caches`, `~/.gradle/wrapper/dists`
 - [ ] **CocoaPods** — `~/Library/Caches/CocoaPods`
-- [ ] **Xcode DerivedData** — `~/Library/Developer/Xcode/DerivedData`
-- [ ] **Swift Package Manager** — `~/Library/Caches/org.swift.swiftpm`
+- [x] **Xcode DerivedData** — `~/Library/Developer/Xcode/DerivedData` (#17)
+- [x] **Swift Package Manager** — `~/Library/Caches/org.swift.swiftpm` (#11)
 - [ ] **Composer** (PHP) — `~/.cache/composer`, `~/.composer/cache`
 - [ ] **Ruby gems** — `~/.gem`, `~/.bundle/cache`
 - [ ] **Bazel** — `~/.cache/bazel`

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -291,6 +291,15 @@ an essay.
   cache automatically — no per-provider code. If your ecosystem has
   unusually volatile version data, flag it when adding the provider
   so the TTL can be revisited.
+- **SwiftPM / Xcode (#11, #17):** disk-hygiene-only providers are a
+  valid shape — return `None` from `package_id`, skip the
+  OSV/registry arms entirely, and document the Tier-3 E2E exemption
+  in the module header comment so future reviewers don't think the
+  E2E test is missing by accident. For Xcode's `Info.plist`, a tiny
+  XML string scanner (`find` + byte-index slicing) is sufficient and
+  avoids a `plist` crate dependency; Xcode always emits XML for
+  DerivedData's `Info.plist`, and char-boundary-safe slicing keeps
+  multi-byte workspace paths (日本語) from panicking.
 
 <!--
 Template for new entries:

--- a/docs/superpowers/plans/2026-04-20-swiftpm-xcode-providers.md
+++ b/docs/superpowers/plans/2026-04-20-swiftpm-xcode-providers.md
@@ -1,0 +1,1470 @@
+# SwiftPM + Xcode Providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SwiftPM and Xcode DerivedData cache providers to ccmd (issues #11, #17).
+
+**Architecture:** Two independent provider modules (`src/providers/swiftpm.rs`, `src/providers/xcode.rs`) wired through the existing dispatch (`detect`/`semantic_name`/`metadata`/`safety`) in `src/providers/mod.rs`. Neither provider returns a `PackageId`, so OSV/version-check/upgrade-command machinery is untouched. Two new `CacheKind` variants. Static config roots guarded by `exists()` checks — no subprocess probing.
+
+**Tech Stack:** Rust 2024 edition, existing deps (no new crates). `tempfile` for fixture-driven tests. All tests strict TDD: red → green → refactor, one assertion per intent.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-swiftpm-xcode-providers-design.md`
+
+---
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `src/tree/node.rs` | Modify: add `SwiftPm` + `Xcode` to `CacheKind` enum with label/description/url |
+| `src/providers/mod.rs` | Modify: add module decls + dispatch arms (`detect`, `semantic_name`, `metadata`, `safety`); `package_id` + `upgrade_command` fall through |
+| `src/providers/swiftpm.rs` | Create: SwiftPM provider (semantic_name, metadata; no package_id) |
+| `src/providers/xcode.rs` | Create: Xcode provider (semantic_name, metadata; Info.plist WORKSPACE_PATH extraction; no package_id) |
+| `src/config.rs` | Modify: add default roots for SwiftPM (macOS + Linux) and Xcode (macOS only) |
+| `tests/integration_swiftpm_xcode.rs` | Create: synthetic-fixture pipeline tests (discover + semantic name + safety) |
+| `README.md` | Modify: bump supported-caches count; add table rows |
+| `CHANGELOG.md` | Modify: `[Unreleased]` Added bullets (note OSV/version-check exemption) |
+| `TODO.md` | Modify: tick issues #11 and #17 |
+| `docs/adding-a-provider.md` | Modify: append lessons-learned line after merge |
+
+---
+
+## Task 1: Branch + CacheKind enum additions
+
+**Files:**
+- Modify: `src/tree/node.rs` (CacheKind enum + label/description/url methods)
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feat/swiftpm-xcode-providers
+```
+
+- [ ] **Step 2: Write failing tests for new CacheKind variants**
+
+Append to `src/tree/node.rs` tests module:
+
+```rust
+#[test]
+fn cachekind_swiftpm_label_description_url() {
+    assert_eq!(CacheKind::SwiftPm.label(), "Swift Package Manager");
+    assert!(!CacheKind::SwiftPm.description().is_empty());
+    assert_eq!(
+        CacheKind::SwiftPm.url(),
+        "https://www.swift.org/package-manager/"
+    );
+}
+
+#[test]
+fn cachekind_xcode_label_description_url() {
+    assert_eq!(CacheKind::Xcode.label(), "Xcode");
+    assert!(!CacheKind::Xcode.description().is_empty());
+    assert_eq!(CacheKind::Xcode.url(), "https://developer.apple.com/xcode/");
+}
+```
+
+- [ ] **Step 3: Run tests, confirm compile error (variants don't exist)**
+
+```bash
+cargo test --lib tree::node::tests::cachekind_swiftpm 2>&1 | tail -20
+```
+
+Expected: `error[E0599]: no variant or associated item named 'SwiftPm' found for enum 'CacheKind'`
+
+- [ ] **Step 4: Add variants and method arms**
+
+Edit `src/tree/node.rs`:
+- Add `SwiftPm,` and `Xcode,` to the `CacheKind` enum (before `Unknown`).
+- Add corresponding arms in `label()`, `description()`, and `url()` matching the spec table.
+
+```rust
+// label()
+Self::SwiftPm => "Swift Package Manager",
+Self::Xcode => "Xcode",
+// description()
+Self::SwiftPm => "Swift Package Manager — cached git clones, artifacts, and manifests",
+Self::Xcode => "Xcode build caches — DerivedData, iOS DeviceSupport, Simulator",
+// url()
+Self::SwiftPm => "https://www.swift.org/package-manager/",
+Self::Xcode => "https://developer.apple.com/xcode/",
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+```bash
+cargo test --lib tree::node::tests::cachekind_swiftpm cargo test --lib tree::node::tests::cachekind_xcode
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Run full test suite to confirm no regressions**
+
+```bash
+cargo test --lib
+```
+
+Expected: all tests pass (the dispatcher `_ => None` paths cover the new variants for now).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/tree/node.rs
+git commit -m "feat(providers): add SwiftPm and Xcode variants to CacheKind"
+```
+
+---
+
+## Task 2: SwiftPM provider — module scaffold + detect()
+
+**Files:**
+- Create: `src/providers/swiftpm.rs`
+- Modify: `src/providers/mod.rs` (add `pub mod swiftpm;` + `detect` arm)
+
+- [ ] **Step 1: Write failing detect tests**
+
+Append to `src/providers/mod.rs` tests:
+
+```rust
+#[test]
+fn detect_swiftpm_library_caches_root() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm"
+        )),
+        CacheKind::SwiftPm
+    );
+}
+
+#[test]
+fn detect_swiftpm_linux_cache_root() {
+    assert_eq!(
+        detect(&PathBuf::from("/home/u/.cache/org.swift.swiftpm")),
+        CacheKind::SwiftPm
+    );
+}
+
+#[test]
+fn detect_swiftpm_repositories_subdir() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234"
+        )),
+        CacheKind::SwiftPm
+    );
+}
+
+#[test]
+fn detect_swiftpm_rejects_confusable_suffix() {
+    // L1: substring match would accept this; component match must reject.
+    assert_ne!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm-backup"
+        )),
+        CacheKind::SwiftPm
+    );
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+```bash
+cargo test --lib providers::tests::detect_swiftpm
+```
+
+Expected: all 4 fail (return `Unknown`).
+
+- [ ] **Step 3: Create minimal `swiftpm.rs` + wire detect arm**
+
+`src/providers/swiftpm.rs`:
+
+```rust
+// SwiftPM provider.
+//
+// No `package_id` / `upgrade_command` arms — SwiftPM's package identity
+// requires git-ref parsing that is too brittle for v1, and there's no
+// public registry for version lookups. OSV `SwiftURL` coverage is
+// sparse. Tier-3 E2E tests are intentionally exempt (see design spec).
+
+use super::MetadataField;
+use std::path::Path;
+
+pub fn semantic_name(_path: &Path) -> Option<String> {
+    None
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}
+```
+
+In `src/providers/mod.rs`:
+- Add `pub mod swiftpm;` (alphabetical, after `pre_commit`/`prisma`).
+- Add to `detect()` direct-name arm: `"org.swift.swiftpm" => return CacheKind::SwiftPm,`
+- Add to ancestor-walk arm the same match.
+- Add `CacheKind::SwiftPm => swiftpm::semantic_name(path),` to `semantic_name` dispatch.
+- Add `CacheKind::SwiftPm => swiftpm::metadata(path),` to `metadata` dispatch.
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::tests::detect_swiftpm
+```
+
+Expected: all 4 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/swiftpm.rs src/providers/mod.rs
+git commit -m "feat(providers): scaffold SwiftPM provider with detect()"
+```
+
+---
+
+## Task 3: SwiftPM `semantic_name`
+
+**Files:**
+- Modify: `src/providers/swiftpm.rs`
+
+- [ ] **Step 1: Write failing semantic_name tests**
+
+Append to `src/providers/swiftpm.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn semantic_name_strips_hash_suffix_from_repository() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+        );
+        assert_eq!(semantic_name(&path), Some("swift-collections".into()));
+    }
+
+    #[test]
+    fn semantic_name_strips_long_hash_suffix() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-nio-0123456789abcdef",
+        );
+        assert_eq!(semantic_name(&path), Some("swift-nio".into()));
+    }
+
+    #[test]
+    fn semantic_name_passes_through_artifacts_dir() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/artifacts/MyBinaryDep",
+        );
+        assert_eq!(semantic_name(&path), Some("MyBinaryDep".into()));
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_manifests_file() {
+        // manifest filenames are internal hashes; no meaningful display.
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/manifests/deadbeef1234",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_known_subdir_roots() {
+        // The three subdir names themselves should not be renamed.
+        for subdir in ["repositories", "artifacts", "manifests"] {
+            let path = PathBuf::from(format!(
+                "/Users/j/Library/Caches/org.swift.swiftpm/{subdir}"
+            ));
+            assert_eq!(semantic_name(&path), None, "{subdir}");
+        }
+    }
+
+    #[test]
+    fn semantic_name_handles_non_ascii_package_name() {
+        // L2: no byte-boundary panic.
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/café-abc1234",
+        );
+        assert_eq!(semantic_name(&path), Some("café".into()));
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_name_without_hash_suffix() {
+        // Short/missing hex suffix doesn't match our rule.
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/plain-name",
+        );
+        // No trailing -<hex7+>, so no transformation; fall through to pass-through OR None.
+        // Our rule: repositories subdir requires hash suffix; without it, we still
+        // fall back to the dir name (user-friendly).
+        assert_eq!(semantic_name(&path), Some("plain-name".into()));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+```bash
+cargo test --lib providers::swiftpm::tests
+```
+
+Expected: all 7 fail (current impl returns None for everything).
+
+- [ ] **Step 3: Implement semantic_name**
+
+Replace the stub in `src/providers/swiftpm.rs`:
+
+```rust
+pub fn semantic_name(path: &Path) -> Option<String> {
+    // Determine position relative to `org.swift.swiftpm/<subdir>/<item>`.
+    // We need the immediate parent subdir to decide how to interpret the name.
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Skip the three known subdir roots themselves.
+    if matches!(name.as_str(), "repositories" | "artifacts" | "manifests") {
+        return None;
+    }
+
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    match parent_name.as_str() {
+        "repositories" => Some(strip_hash_suffix(&name)),
+        "artifacts" => Some(name),
+        "manifests" => None, // internal hash filenames
+        _ => None,
+    }
+}
+
+/// Strip a trailing `-<hex>` where hex is 7 or more lowercase-hex chars.
+/// Returns the input unchanged if no such suffix exists.
+fn strip_hash_suffix(s: &str) -> String {
+    let Some(dash_idx) = s.rfind('-') else {
+        return s.to_string();
+    };
+    let suffix = &s[dash_idx + 1..];
+    if suffix.len() >= 7 && suffix.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()) {
+        s[..dash_idx].to_string()
+    } else {
+        s.to_string()
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::swiftpm::tests
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+cargo test --lib
+```
+
+Expected: no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/providers/swiftpm.rs
+git commit -m "feat(swiftpm): semantic_name with hash-suffix stripping"
+```
+
+---
+
+## Task 4: SwiftPM `metadata`
+
+**Files:**
+- Modify: `src/providers/swiftpm.rs`
+
+- [ ] **Step 1: Write failing metadata tests**
+
+Add to the tests module in `src/providers/swiftpm.rs`:
+
+```rust
+#[test]
+fn metadata_repositories_root_reports_contents() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/repositories",
+    );
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("Git clones")));
+}
+
+#[test]
+fn metadata_artifacts_root_reports_contents() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/artifacts",
+    );
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("Binary artifacts")));
+}
+
+#[test]
+fn metadata_manifests_root_reports_contents() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/manifests",
+    );
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("Package.swift")));
+}
+
+#[test]
+fn metadata_leaf_file_returns_empty() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+    );
+    assert!(metadata(&path).is_empty());
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: 3 fail (the `_leaf_` test passes since the stub already returns empty).
+
+- [ ] **Step 3: Implement metadata**
+
+Replace the stub:
+
+```rust
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent_is_swiftpm = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .is_some_and(|n| n == "org.swift.swiftpm");
+    if parent_is_swiftpm {
+        let value = match name.as_str() {
+            "repositories" => Some("Git clones of package sources (re-cloneable)"),
+            "artifacts" => Some("Binary artifacts (re-downloadable)"),
+            "manifests" => Some("Cached Package.swift resolutions"),
+            _ => None,
+        };
+        if let Some(v) = value {
+            fields.push(MetadataField {
+                label: "Contents".to_string(),
+                value: v.to_string(),
+            });
+        }
+    }
+    fields
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::swiftpm::tests
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/swiftpm.rs
+git commit -m "feat(swiftpm): metadata for root subdirs"
+```
+
+---
+
+## Task 5: SwiftPM `safety` (dispatch in mod.rs)
+
+**Files:**
+- Modify: `src/providers/mod.rs` (safety arm)
+
+- [ ] **Step 1: Write failing safety tests**
+
+Append to `src/providers/mod.rs` tests:
+
+```rust
+#[test]
+fn safety_swiftpm_repositories_is_caution() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+    );
+    assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Caution);
+}
+
+#[test]
+fn safety_swiftpm_artifacts_is_safe() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/artifacts/MyBinaryDep",
+    );
+    assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Safe);
+}
+
+#[test]
+fn safety_swiftpm_manifests_is_safe() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/manifests/deadbeef",
+    );
+    assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Safe);
+}
+
+#[test]
+fn safety_swiftpm_unknown_subdir_is_caution() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/futuredir/item",
+    );
+    assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Caution);
+}
+
+#[test]
+fn safety_swiftpm_rejects_confusable_suffix() {
+    // L1: `repositories-old` must NOT classify as repositories.
+    let path = PathBuf::from(
+        "/Users/j/Library/Caches/org.swift.swiftpm/repositories-old/foo",
+    );
+    // This should be Caution (unknown subdir), not specifically
+    // "repositories Caution" — but both are Caution. Verify the *reason*
+    // by also checking a Safe path with confusable parent.
+    assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Caution);
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: `safety_swiftpm_artifacts_is_safe` and `_manifests_is_safe` fail (currently falls through to `Safe` default — wait, actually the default IS Safe. So those two would pass. The two Caution expectations would fail).
+
+- [ ] **Step 3: Implement safety arm**
+
+In `src/providers/mod.rs`, add to the `safety()` function match before the `_ => SafetyLevel::Safe` fallback:
+
+```rust
+CacheKind::SwiftPm => {
+    // Walk path components looking for the known subdir immediately
+    // after `org.swift.swiftpm`. Component-based to avoid L1 substring
+    // false positives.
+    let comps: Vec<&std::ffi::OsStr> = path.components().map(|c| c.as_os_str()).collect();
+    let mut classified = None;
+    for w in comps.windows(2) {
+        if w[0] == "org.swift.swiftpm" {
+            classified = match w[1].to_string_lossy().as_ref() {
+                "repositories" => Some(SafetyLevel::Caution),
+                "artifacts" | "manifests" => Some(SafetyLevel::Safe),
+                _ => Some(SafetyLevel::Caution), // unknown future subdirs
+            };
+            break;
+        }
+    }
+    // Exact-root case (path is `.../org.swift.swiftpm` itself): Caution.
+    classified.unwrap_or(SafetyLevel::Caution)
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::tests::safety_swiftpm
+```
+
+Expected: all 5 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/mod.rs
+git commit -m "feat(swiftpm): safety classification (repositories=Caution, others=Safe)"
+```
+
+---
+
+## Task 6: Xcode provider — module scaffold + detect()
+
+**Files:**
+- Create: `src/providers/xcode.rs`
+- Modify: `src/providers/mod.rs`
+
+- [ ] **Step 1: Write failing detect tests**
+
+Append to `src/providers/mod.rs` tests:
+
+```rust
+#[test]
+fn detect_xcode_derived_data() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Developer/Xcode/DerivedData"
+        )),
+        CacheKind::Xcode
+    );
+}
+
+#[test]
+fn detect_xcode_derived_data_project_subdir() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Developer/Xcode/DerivedData/MyApp-abc123def456"
+        )),
+        CacheKind::Xcode
+    );
+}
+
+#[test]
+fn detect_xcode_ios_device_support() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)"
+        )),
+        CacheKind::Xcode
+    );
+}
+
+#[test]
+fn detect_xcode_core_simulator_caches() {
+    assert_eq!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Developer/CoreSimulator/Caches/something"
+        )),
+        CacheKind::Xcode
+    );
+}
+
+#[test]
+fn detect_xcode_rejects_confusable_suffix() {
+    // L1: Xcode/DerivedData-backup must not match.
+    assert_ne!(
+        detect(&PathBuf::from(
+            "/Users/j/Library/Developer/Xcode/DerivedData-backup"
+        )),
+        CacheKind::Xcode
+    );
+}
+
+#[test]
+fn detect_xcode_rejects_unrelated_derived_data() {
+    // A DerivedData directory not under Xcode must not match.
+    assert_ne!(
+        detect(&PathBuf::from("/random/path/DerivedData")),
+        CacheKind::Xcode
+    );
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: all 4 positive cases fail (return Unknown). Negative cases pass trivially.
+
+- [ ] **Step 3: Create `xcode.rs` + wire detect**
+
+`src/providers/xcode.rs`:
+
+```rust
+// Xcode provider (DerivedData, iOS DeviceSupport, CoreSimulator Caches).
+//
+// No package identity / OSV / version-check / upgrade-command: these are
+// build artifacts, not packages. Tier-3 E2E tests intentionally exempt
+// (see design spec).
+
+use super::MetadataField;
+use std::path::Path;
+
+pub fn semantic_name(_path: &Path) -> Option<String> {
+    None
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}
+```
+
+In `src/providers/mod.rs`:
+- Add `pub mod xcode;` (alphabetical).
+- Add `CacheKind::Xcode => xcode::semantic_name(path),` to `semantic_name` dispatch.
+- Add `CacheKind::Xcode => xcode::metadata(path),` to `metadata` dispatch.
+- In `detect()`, add this block BEFORE the final `Unknown` return:
+
+```rust
+if has_adjacent_components(path, "Xcode", "DerivedData")
+    || has_adjacent_components(path, "Xcode", "iOS DeviceSupport")
+    || has_adjacent_components(path, "CoreSimulator", "Caches")
+{
+    return CacheKind::Xcode;
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::tests::detect_xcode
+```
+
+Expected: 6 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/xcode.rs src/providers/mod.rs
+git commit -m "feat(providers): scaffold Xcode provider with detect()"
+```
+
+---
+
+## Task 7: Xcode `semantic_name` — DerivedData Info.plist extraction
+
+**Files:**
+- Modify: `src/providers/xcode.rs`
+
+- [ ] **Step 1: Write failing semantic_name tests**
+
+Append to `src/providers/xcode.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn make_derived_data_dir(tmp: &tempfile::TempDir, workspace_path: Option<&str>) -> PathBuf {
+        let root = tmp.path().join("Library/Developer/Xcode/DerivedData/MyApp-abc123def");
+        std::fs::create_dir_all(&root).unwrap();
+        if let Some(wp) = workspace_path {
+            let plist = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>WORKSPACE_PATH</key>
+    <string>{wp}</string>
+</dict>
+</plist>"#
+            );
+            std::fs::write(root.join("Info.plist"), plist).unwrap();
+        }
+        root
+    }
+
+    #[test]
+    fn semantic_name_derived_data_from_info_plist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, Some("/Users/j/dev/MyApp/MyApp.xcworkspace"));
+        assert_eq!(
+            semantic_name(&dir),
+            Some("MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_derived_data_missing_plist_falls_back_to_dirname() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, None);
+        assert_eq!(semantic_name(&dir), Some("MyApp-abc123def".into()));
+    }
+
+    #[test]
+    fn semantic_name_derived_data_malformed_plist_falls_back_to_dirname() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("Library/Developer/Xcode/DerivedData/Broken-xyz");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("Info.plist"), "<plist><incomplete").unwrap();
+        assert_eq!(semantic_name(&root), Some("Broken-xyz".into()));
+    }
+
+    #[test]
+    fn semantic_name_derived_data_non_ascii_workspace_path() {
+        // L2 / L5: no panic on multi-byte chars.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, Some("/Users/j/日本語/App.xcworkspace"));
+        assert_eq!(
+            semantic_name(&dir),
+            Some("App.xcworkspace (at /Users/j/日本語/App.xcworkspace)".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_ios_device_support_uses_dirname() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)",
+        );
+        assert_eq!(semantic_name(&path), Some("17.4 (21E213)".into()));
+    }
+
+    #[test]
+    fn semantic_name_core_simulator_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Developer/CoreSimulator/Caches/com.apple.SimulatorTrampoline",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_known_roots_return_none() {
+        // The three root directories themselves should render literally.
+        for p in [
+            "/Users/j/Library/Developer/Xcode/DerivedData",
+            "/Users/j/Library/Developer/Xcode/iOS DeviceSupport",
+            "/Users/j/Library/Developer/CoreSimulator/Caches",
+        ] {
+            assert_eq!(semantic_name(&PathBuf::from(p)), None, "{p}");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: the two `_returns_none` tests pass (stub returns None); the 5 positive cases fail.
+
+- [ ] **Step 3: Implement semantic_name**
+
+Replace the stub in `src/providers/xcode.rs`:
+
+```rust
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Known root subdirs — render literally.
+    if matches!(name.as_str(), "DerivedData" | "iOS DeviceSupport" | "Caches") {
+        return None;
+    }
+
+    // DerivedData project dir: try Info.plist WORKSPACE_PATH, fall back to name.
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if parent_name == "DerivedData" {
+        if let Some(workspace_path) = read_workspace_path(path) {
+            let basename = workspace_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(&workspace_path)
+                .to_string();
+            return Some(format!("{basename} (at {workspace_path})"));
+        }
+        return Some(name);
+    }
+
+    if parent_name == "iOS DeviceSupport" {
+        return Some(name);
+    }
+
+    // CoreSimulator/Caches entries: opaque, no semantic name.
+    None
+}
+
+/// Read WORKSPACE_PATH from Info.plist (XML variant).
+/// Returns None on any failure (missing file, malformed XML, missing key).
+fn read_workspace_path(dir: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(dir.join("Info.plist")).ok()?;
+    extract_plist_string(&content, "WORKSPACE_PATH")
+}
+
+/// Extract a string value by key from an XML plist body. Simple string
+/// scanner — avoids a plist-crate dependency. Uses char-boundary-safe
+/// string APIs (L2, L5).
+fn extract_plist_string(xml: &str, key: &str) -> Option<String> {
+    let key_tag = format!("<key>{key}</key>");
+    let key_pos = xml.find(&key_tag)?;
+    let after_key = &xml[key_pos + key_tag.len()..];
+    let open = "<string>";
+    let open_pos = after_key.find(open)?;
+    let value_start = open_pos + open.len();
+    let close_pos = after_key[value_start..].find("</string>")?;
+    let value = &after_key[value_start..value_start + close_pos];
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::xcode::tests
+```
+
+Expected: 7 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/xcode.rs
+git commit -m "feat(xcode): semantic_name with Info.plist WORKSPACE_PATH extraction"
+```
+
+---
+
+## Task 8: Xcode `metadata`
+
+**Files:**
+- Modify: `src/providers/xcode.rs`
+
+- [ ] **Step 1: Write failing metadata tests**
+
+Add to the `xcode::tests` module:
+
+```rust
+#[test]
+fn metadata_derived_data_root_reports_contents() {
+    let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData");
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("build products")));
+}
+
+#[test]
+fn metadata_ios_device_support_root_reports_contents() {
+    let path = PathBuf::from("/Users/j/Library/Developer/Xcode/iOS DeviceSupport");
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("Symbol files")));
+}
+
+#[test]
+fn metadata_core_simulator_caches_root_reports_contents() {
+    let path = PathBuf::from("/Users/j/Library/Developer/CoreSimulator/Caches");
+    let fields = metadata(&path);
+    assert!(fields.iter().any(|f| f.label == "Contents" && f.value.contains("Simulator")));
+}
+
+#[test]
+fn metadata_derived_data_project_dir_emits_workspace_path_when_available() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = make_derived_data_dir(&tmp, Some("/Users/j/dev/MyApp/MyApp.xcworkspace"));
+    let fields = metadata(&dir);
+    assert!(
+        fields.iter().any(|f| f.label == "Workspace"
+            && f.value == "/Users/j/dev/MyApp/MyApp.xcworkspace"),
+        "expected Workspace field, got {fields:?}"
+    );
+}
+
+#[test]
+fn metadata_derived_data_project_dir_without_plist_is_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = make_derived_data_dir(&tmp, None);
+    assert!(metadata(&dir).is_empty());
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: 4 fail (the `_without_plist_is_empty` passes since stub returns empty).
+
+- [ ] **Step 3: Implement metadata**
+
+Replace the stub:
+
+```rust
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Root-level labels.
+    match name.as_str() {
+        "DerivedData" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Xcode build products and indexes (rebuildable, 5–30 min cost)".into(),
+            });
+            return fields;
+        }
+        "iOS DeviceSupport" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Symbol files for connected iOS devices (re-downloadable on device reconnect)".into(),
+            });
+            return fields;
+        }
+        "Caches" if parent_name == "CoreSimulator" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "iOS Simulator caches (safe to clear)".into(),
+            });
+            return fields;
+        }
+        _ => {}
+    }
+
+    // DerivedData project dir: surface WORKSPACE_PATH if present.
+    if parent_name == "DerivedData"
+        && let Some(wp) = read_workspace_path(path)
+    {
+        fields.push(MetadataField {
+            label: "Workspace".into(),
+            value: wp,
+        });
+    }
+
+    fields
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::xcode::tests
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/xcode.rs
+git commit -m "feat(xcode): metadata for roots and DerivedData project dirs"
+```
+
+---
+
+## Task 9: Xcode `safety` (dispatch in mod.rs)
+
+**Files:**
+- Modify: `src/providers/mod.rs`
+
+- [ ] **Step 1: Write failing safety tests**
+
+Append to `src/providers/mod.rs` tests:
+
+```rust
+#[test]
+fn safety_xcode_derived_data_is_caution() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Developer/Xcode/DerivedData/MyApp-abc",
+    );
+    assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Caution);
+}
+
+#[test]
+fn safety_xcode_ios_device_support_is_safe() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)",
+    );
+    assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+}
+
+#[test]
+fn safety_xcode_core_simulator_caches_is_safe() {
+    let path = PathBuf::from(
+        "/Users/j/Library/Developer/CoreSimulator/Caches/something",
+    );
+    assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+}
+
+#[test]
+fn safety_xcode_rejects_confusable_suffix_derived_data() {
+    // L1: DerivedData-backup must not be classified as Caution-DerivedData.
+    // Under CacheKind::Xcode, any path not matching a known subtree
+    // falls through to Safe default.
+    let path = PathBuf::from(
+        "/Users/j/Library/Developer/Xcode/DerivedData-backup/junk",
+    );
+    assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+}
+```
+
+- [ ] **Step 2: Run tests, confirm fail**
+
+Expected: `_derived_data_is_caution` fails (default is Safe). Others pass trivially.
+
+- [ ] **Step 3: Add Xcode safety arm**
+
+In `src/providers/mod.rs`, add to `safety()` match before the `_` fallback:
+
+```rust
+CacheKind::Xcode => {
+    // Only DerivedData triggers Caution (rebuild cost). iOS
+    // DeviceSupport and CoreSimulator caches are Safe. Component-based
+    // matching avoids L1 substring leaks.
+    if has_adjacent_components(path, "Xcode", "DerivedData") {
+        SafetyLevel::Caution
+    } else {
+        SafetyLevel::Safe
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib providers::tests::safety_xcode
+```
+
+Expected: 4 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/providers/mod.rs
+git commit -m "feat(xcode): safety classification (DerivedData=Caution, others=Safe)"
+```
+
+---
+
+## Task 10: Config — default roots for SwiftPM and Xcode
+
+**Files:**
+- Modify: `src/config.rs`
+
+- [ ] **Step 1: Write failing config test**
+
+Append to `src/config.rs` tests module:
+
+```rust
+#[test]
+#[cfg(target_os = "macos")]
+fn default_config_includes_swiftpm_on_macos_when_exists() {
+    let swiftpm = dirs_home().join("Library/Caches/org.swift.swiftpm");
+    if !swiftpm.exists() {
+        return; // graceful skip on hosts without SwiftPM
+    }
+    let config = Config::default();
+    assert!(
+        config.roots.iter().any(|r| r == &swiftpm),
+        "expected SwiftPM root in config, got {:?}",
+        config.roots
+    );
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn default_config_includes_derived_data_when_exists() {
+    let dd = dirs_home().join("Library/Developer/Xcode/DerivedData");
+    if !dd.exists() {
+        return;
+    }
+    let config = Config::default();
+    assert!(config.roots.iter().any(|r| r == &dd));
+}
+
+#[test]
+fn default_for_test_is_empty_roots() {
+    // Regression guard: adding new roots must not leak into test config.
+    assert!(Config::default_for_test().roots.is_empty());
+}
+```
+
+- [ ] **Step 2: Run tests, confirm they fail (if Xcode is installed locally) or skip**
+
+```bash
+cargo test --lib config::tests::default_config_includes_swiftpm
+cargo test --lib config::tests::default_config_includes_derived_data
+cargo test --lib config::tests::default_for_test_is_empty_roots
+```
+
+Expected: the two macOS path tests either fail (if dirs exist) or skip cleanly. The `default_for_test` test passes.
+
+- [ ] **Step 3: Add default roots**
+
+In `src/config.rs`, inside `impl Default for Config`, add after the existing `gradle_caches` block and before the `probe_yarn_paths()` block:
+
+```rust
+#[cfg(target_os = "macos")]
+{
+    let swiftpm = home.join("Library/Caches/org.swift.swiftpm");
+    if swiftpm.exists() {
+        roots.push(swiftpm);
+    }
+    let derived_data = home.join("Library/Developer/Xcode/DerivedData");
+    if derived_data.exists() {
+        roots.push(derived_data);
+    }
+    let device_support = home.join("Library/Developer/Xcode/iOS DeviceSupport");
+    if device_support.exists() {
+        roots.push(device_support);
+    }
+    let coresim_caches = home.join("Library/Developer/CoreSimulator/Caches");
+    if coresim_caches.exists() {
+        roots.push(coresim_caches);
+    }
+}
+
+// Linux SwiftPM (macOS path handled above).
+#[cfg(not(target_os = "macos"))]
+{
+    let swiftpm_linux = home.join(".cache/org.swift.swiftpm");
+    if swiftpm_linux.exists() && !roots.contains(&swiftpm_linux) {
+        roots.push(swiftpm_linux);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+cargo test --lib config
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs
+git commit -m "feat(config): add default roots for SwiftPM and Xcode caches"
+```
+
+---
+
+## Task 11: Integration test — synthetic-fixture pipeline
+
+**Files:**
+- Create: `tests/integration_swiftpm_xcode.rs`
+
+- [ ] **Step 1: Write the integration test**
+
+```rust
+// Integration test: synthetic SwiftPM + Xcode cache fixtures exercise the
+// full detect → semantic_name → metadata → safety pipeline.
+//
+// E2E exempt per design spec: neither provider participates in OSV /
+// version-check, so the standard "install tool, download vulnerable
+// package" rubric does not apply.
+
+use ccmd::providers::{self, SafetyLevel};
+use ccmd::tree::node::CacheKind;
+use std::fs;
+
+#[test]
+fn swiftpm_fixture_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("Library/Caches/org.swift.swiftpm");
+    let repo = root.join("repositories/swift-collections-abc1234");
+    let artifact = root.join("artifacts/MyBinaryDep");
+    let manifest = root.join("manifests/deadbeef12345");
+    fs::create_dir_all(&repo).unwrap();
+    fs::create_dir_all(&artifact).unwrap();
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::write(&manifest, b"").unwrap();
+
+    // detect()
+    assert_eq!(providers::detect(&root), CacheKind::SwiftPm);
+    assert_eq!(providers::detect(&repo), CacheKind::SwiftPm);
+
+    // semantic_name()
+    assert_eq!(
+        providers::semantic_name(CacheKind::SwiftPm, &repo),
+        Some("swift-collections".into())
+    );
+    assert_eq!(
+        providers::semantic_name(CacheKind::SwiftPm, &artifact),
+        Some("MyBinaryDep".into())
+    );
+
+    // safety()
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &repo),
+        SafetyLevel::Caution
+    );
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &artifact),
+        SafetyLevel::Safe
+    );
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &manifest),
+        SafetyLevel::Safe
+    );
+}
+
+#[test]
+fn xcode_fixture_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dd = tmp
+        .path()
+        .join("Library/Developer/Xcode/DerivedData/MyApp-abc123def");
+    fs::create_dir_all(&dd).unwrap();
+    let plist = r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>WORKSPACE_PATH</key>
+    <string>/Users/j/dev/MyApp/MyApp.xcworkspace</string>
+</dict>
+</plist>"#;
+    fs::write(dd.join("Info.plist"), plist).unwrap();
+
+    let ds = tmp
+        .path()
+        .join("Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)");
+    fs::create_dir_all(&ds).unwrap();
+
+    let sim = tmp
+        .path()
+        .join("Library/Developer/CoreSimulator/Caches/com.apple.Sim");
+    fs::create_dir_all(&sim).unwrap();
+
+    // detect
+    assert_eq!(providers::detect(&dd), CacheKind::Xcode);
+    assert_eq!(providers::detect(&ds), CacheKind::Xcode);
+    assert_eq!(providers::detect(&sim), CacheKind::Xcode);
+
+    // semantic_name
+    assert_eq!(
+        providers::semantic_name(CacheKind::Xcode, &dd),
+        Some("MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)".into())
+    );
+    assert_eq!(
+        providers::semantic_name(CacheKind::Xcode, &ds),
+        Some("17.4 (21E213)".into())
+    );
+    assert_eq!(providers::semantic_name(CacheKind::Xcode, &sim), None);
+
+    // safety
+    assert_eq!(providers::safety(CacheKind::Xcode, &dd), SafetyLevel::Caution);
+    assert_eq!(providers::safety(CacheKind::Xcode, &ds), SafetyLevel::Safe);
+    assert_eq!(providers::safety(CacheKind::Xcode, &sim), SafetyLevel::Safe);
+}
+```
+
+Note: if the crate's lib name differs from `ccmd`, adjust imports. (Verify via `cargo pkgid` or look at existing `tests/` files.)
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+cargo test --test integration_swiftpm_xcode
+```
+
+Expected: pass. If import errors, check `Cargo.toml` for the library name and adjust.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration_swiftpm_xcode.rs
+git commit -m "test: integration pipeline for SwiftPM + Xcode providers"
+```
+
+---
+
+## Task 12: Docs — README, CHANGELOG, TODO
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `TODO.md`
+
+- [ ] **Step 1: Update README**
+
+Add rows to the Supported Caches table (locate it via `grep -n "Supported Caches" README.md`) for SwiftPM and Xcode. Bump the provider count in the Features bullet.
+
+- [ ] **Step 2: Update CHANGELOG**
+
+Under `## [Unreleased]` / `### Added`:
+
+```markdown
+- **SwiftPM provider** — detects `~/Library/Caches/org.swift.swiftpm/` (macOS) and `~/.cache/org.swift.swiftpm/` (Linux); reports Caution safety for `repositories/` (re-clone cost), Safe for `artifacts/` and `manifests/`. No OSV or version-check (package-identity extraction is too brittle in v1 and OSV `SwiftURL` coverage is sparse); the `c` upgrade shortcut is a no-op for SwiftPM entries by design. (#11)
+- **Xcode provider** — detects `~/Library/Developer/Xcode/DerivedData/`, `~/Library/Developer/Xcode/iOS DeviceSupport/`, and `~/Library/Developer/CoreSimulator/Caches/`. DerivedData is Caution (rebuild takes 5–30 min); the other two are Safe. Project dirs show the workspace path from `Info.plist` in the detail panel. No package identity (these are build artifacts, not packages). (#17)
+```
+
+- [ ] **Step 3: Update TODO.md**
+
+Tick issues #11 and #17 (whatever the existing format is). Open the file first to see the format.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md TODO.md
+git commit -m "docs: add SwiftPM and Xcode provider entries"
+```
+
+---
+
+## Task 13: Full verification + cleanup
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cargo test
+cargo test --features mcp
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Clippy + fmt**
+
+```bash
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Package list sanity check**
+
+```bash
+cargo package --list --allow-dirty | grep -E "swiftpm|xcode"
+```
+
+Expected: the two new provider files listed, nothing else weird.
+
+- [ ] **Step 4: Append lessons-learned entry to adding-a-provider.md**
+
+Under `## 5. Lessons learned`, append:
+
+```markdown
+- **SwiftPM / Xcode (PR #?, v0.3.2?):** providers without package identity
+  (disk-hygiene only) are a valid shape — return `None` from
+  `package_id`, omit the OSV/registry arms, and document the Tier-3 E2E
+  exemption in the module header comment so a future reviewer doesn't
+  think the E2E test is missing by accident. Info.plist's XML format is
+  stable enough to parse via string search; no `plist` crate needed.
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add docs/adding-a-provider.md
+git commit -m "docs: lessons-learned note for disk-hygiene-only providers"
+```
+
+- [ ] **Step 6: Push branch + open PR**
+
+```bash
+git push -u origin feat/swiftpm-xcode-providers
+gh pr create --title "Add SwiftPM + Xcode DerivedData providers (#11, #17)" --body "$(cat <<'EOF'
+## Summary
+- Two new macOS-centric cache providers: **SwiftPM** (#11) and **Xcode DerivedData** (#17).
+- SwiftPM classifies `repositories/` as Caution (re-clone), `artifacts/`+`manifests/` as Safe.
+- Xcode DerivedData is Caution (rebuild cost 5–30 min); iOS DeviceSupport + CoreSimulator/Caches are Safe.
+- Neither provider returns a `PackageId` — OSV, version-check, and upgrade-command are untouched (pure disk hygiene).
+- Xcode DerivedData project dirs extract `WORKSPACE_PATH` from `Info.plist` for detail-panel display.
+
+## Test plan
+- [x] `cargo test` green (unit + integration)
+- [x] `cargo clippy --all-targets -- -D warnings` clean
+- [x] `cargo fmt --all -- --check` clean
+- [x] L1 confusable-suffix guards on both providers
+- [x] L2 non-ASCII handling in semantic_name / Info.plist
+- [ ] Manual smoke: run `ccmd` on a machine with SwiftPM + Xcode populated caches
+
+## Design
+See `docs/superpowers/specs/2026-04-20-swiftpm-xcode-providers-design.md`.
+
+## E2E exemption
+Both providers are disk-hygiene-only — no OSV ecosystem, no registry, no upgrade command. The standard Tier-3 E2E rubric (install tool, download vulnerable package, verify OSV + version-check fire) does not apply. Coverage is Tier 1 (unit) + Tier 2 (integration with synthetic fixtures).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: every section of the spec maps to a task. ✓
+- No placeholders. ✓
+- Type consistency: `CacheKind::SwiftPm` and `CacheKind::Xcode` used consistently; function signatures match `maven.rs` reference. ✓
+- Task granularity: 13 tasks, each 2–10 min of work. Multiple commits per provider to preserve bisectability. ✓

--- a/docs/superpowers/specs/2026-04-20-swiftpm-xcode-providers-design.md
+++ b/docs/superpowers/specs/2026-04-20-swiftpm-xcode-providers-design.md
@@ -1,0 +1,288 @@
+# SwiftPM & Xcode DerivedData Provider Support
+
+**Date:** 2026-04-20
+**Issues:** [#11](https://github.com/juliensimon/cache-commander/issues/11), [#17](https://github.com/juliensimon/cache-commander/issues/17)
+**Status:** Design
+
+## Summary
+
+Add two macOS-centric cache providers: **SwiftPM** (Swift Package Manager's global cache of git clones, artifacts, and manifests) and **Xcode** (DerivedData, iOS DeviceSupport, CoreSimulator Caches). Both are disk-hygiene-focused — neither participates in OSV vulnerability scanning or version-check registries. DerivedData is frequently the single largest cache on macOS developer machines (50–200 GB is typical), so correct detection and safe-deletion classification is the primary user value.
+
+## Approach
+
+Two independent providers, one PR. Both providers are additive: no changes to existing scanner, detection, or UI logic. Both ship under hardcore TDD — every function has at least one red→green test cycle, written before implementation.
+
+## Provider: SwiftPM (`src/providers/swiftpm.rs`)
+
+### Detection
+
+`detect(path)` returns `CacheKind::SwiftPm` when any path component is `org.swift.swiftpm`, OR when an ancestor is `org.swift.swiftpm` (catches deep paths into `repositories/`, `artifacts/`, `manifests/`).
+
+Canonical roots:
+- `~/Library/Caches/org.swift.swiftpm/` (macOS)
+- `~/.cache/org.swift.swiftpm/` (Linux)
+
+### Package Identification
+
+**None.** `package_id()` returns `None` unconditionally.
+
+Rationale (per brainstorming):
+- Version extraction from `repositories/<name>-<hash>/` requires parsing git refs, which is brittle and depends on resolver state we don't control.
+- OSV's `SwiftURL` ecosystem has sparse coverage; implementing identity would add complexity for little scanning value.
+- Disk hygiene is the primary user value. Identity can be added in a future PR once the `artifacts/` layout and OSV coverage mature.
+
+Follow-up tracking issue to be filed after this PR lands.
+
+### Semantic Names
+
+- `repositories/<pkg>-<8-hex-hash>/` → `<pkg>` (strip trailing `-<8hex>` hash suffix). Example: `swift-collections-a1b2c3d4` → `swift-collections`.
+- `artifacts/<pkg>/` → `<pkg>` (plain passthrough when the component is directly under `artifacts/`).
+- `manifests/<filename>` → `None` (filenames are internal hashes, no meaningful display).
+- The three known root-subdir names themselves (`repositories`, `artifacts`, `manifests`) → `None` (let the tree show them literally).
+
+Hash detection rule: a trailing segment is treated as a hash iff it is `-` followed by 7 or more lowercase-hex characters at the end of the component. Exact minimum length is pinned by tests against real SwiftPM cache fixtures during TDD. False positives on real package names (e.g. a package literally named `x-abcdefg`) are acceptable since stripping still yields a human-readable name.
+
+### Metadata
+
+`metadata()` returns contextual labels for the three top-level subdirs:
+- `repositories/` → `Contents: Git clones of package sources (re-cloneable)`
+- `artifacts/` → `Contents: Binary artifacts (re-downloadable)`
+- `manifests/` → `Contents: Cached Package.swift resolutions`
+
+No metadata for leaf files.
+
+### Safety
+
+- `repositories/` subtree → `SafetyLevel::Caution` (deleting forces a full re-clone of every dependency; slow on first rebuild).
+- `artifacts/` subtree → `SafetyLevel::Safe`.
+- `manifests/` subtree → `SafetyLevel::Safe`.
+- Anything else under `org.swift.swiftpm/` (future subdirs we don't know about yet) → `SafetyLevel::Caution` (conservative default).
+
+Classification uses `has_adjacent_components(path, "org.swift.swiftpm", "repositories")` (L1-safe component matching), not substring checks.
+
+### Upgrade Command
+
+`None`. Swift package upgrades are project-local operations on `Package.swift` / `Package.resolved`, not on global cache entries. Documented in CHANGELOG so users aren't surprised the `c` key is a no-op for SwiftPM entries.
+
+### Registry / OSV
+
+Neither `build_registry_url` nor `check_latest` needs an arm. `package_id` returns `None`, so the scanner never queries either pipeline for SwiftPM.
+
+## Provider: Xcode (`src/providers/xcode.rs`)
+
+Single provider, three distinct root paths. Name chosen to reflect the umbrella (Xcode ecosystem), not just one subdir.
+
+### Detection
+
+`detect(path)` returns `CacheKind::Xcode` when `has_adjacent_components` (L1-safe) matches any of these pairs anywhere in `path.ancestors()`:
+
+- `Xcode/DerivedData` (covers the `~/Library/Developer/Xcode/DerivedData/` subtree and deep paths within it)
+- `Xcode/iOS DeviceSupport`
+- `CoreSimulator/Caches`
+
+No unqualified direct-name arm for `DerivedData` or `Caches` alone — those names are too ambiguous and would collide with unrelated directories. The adjacent-components requirement is the whole guard.
+
+### Package Identification
+
+**None.** No ecosystem, no OSV coverage. Pure disk hygiene.
+
+### Semantic Names
+
+**DerivedData:** For a path `.../DerivedData/<Project>-<hash>/` (top-level project directory):
+1. Open `Info.plist` inside that directory.
+2. Extract the `WORKSPACE_PATH` string value.
+3. Display as `<basename of WORKSPACE_PATH> (at <full WORKSPACE_PATH>)`.
+
+Example: if `Info.plist` contains `<key>WORKSPACE_PATH</key><string>/Users/j/dev/MyApp/MyApp.xcworkspace</string>`, the semantic name is `MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)`.
+
+Fallback when `Info.plist` is missing, unreadable, or lacks `WORKSPACE_PATH`: return the directory name as-is (e.g. `MyApp-abc123def`). Never panic, never propagate errors.
+
+**Info.plist parsing:** XML format only (Xcode consistently writes XML, not the binary variant). Simple string search for the `WORKSPACE_PATH` `<key>` / `<string>` pair — no added dependency on a plist crate. Must use `chars()`-based handling if slicing (L2, L5 guard).
+
+**iOS DeviceSupport:** Leaf directories are named `<iOS-version> (<build>)` (e.g. `17.4 (21E213)`). Use the directory name directly as the semantic name.
+
+**CoreSimulator/Caches:** No meaningful semantic name — directory layout is opaque. Return `None`.
+
+### Metadata
+
+`metadata()` returns root-level labels:
+- `DerivedData/` → `Contents: Xcode build products and indexes (rebuildable, 5–30 min cost)`
+- `iOS DeviceSupport/` → `Contents: Symbol files for connected iOS devices (re-downloadable on device reconnect)`
+- `CoreSimulator/Caches/` → `Contents: iOS Simulator caches (safe to clear)`
+
+For a DerivedData project dir, additionally emit the `WORKSPACE_PATH` as a metadata field when available, so the user can confirm which project they're about to nuke before confirming the delete.
+
+### Safety
+
+- `DerivedData/` subtree → `SafetyLevel::Caution` (rebuild is real and slow; matches Gradle's transform/build-cache classification).
+- `iOS DeviceSupport/` subtree → `SafetyLevel::Safe` (re-downloaded automatically on next device connect).
+- `CoreSimulator/Caches/` subtree → `SafetyLevel::Safe`.
+
+Classification via `has_adjacent_components`. Explicit test `safety_rejects_confusable_suffix` covers `DerivedData-backup/`, `DerivedDatabase/`, `iOS DeviceSupport-old/` and asserts they are NOT classified as the real subtree.
+
+### Upgrade Command
+
+`None`. These are build artifacts, not package entries.
+
+### Registry / OSV
+
+Neither applies. No changes to `registry.rs` or `osv.rs`.
+
+## Dispatch Integration (`src/providers/mod.rs`)
+
+Add `pub mod swiftpm;` and `pub mod xcode;` declarations (preserving alphabetical order: `swiftpm` after `pre_commit`/`prisma`, `xcode` after `whisper`/`yarn`).
+
+Add `CacheKind::SwiftPm` and `CacheKind::Xcode` arms to:
+
+- `detect()` — direct-name + ancestor-walk arms as described above.
+- `semantic_name()` — dispatch to `swiftpm::semantic_name` / `xcode::semantic_name`.
+- `metadata()` — dispatch to `swiftpm::metadata` / `xcode::metadata`.
+- `package_id()` — **no arm added**; they fall through to `_ => None` (documented in the match as a comment).
+- `upgrade_command()` — **no arm added**; same fall-through.
+- `safety()` — dedicated arms for both (replaces the default `Safe`).
+
+## CacheKind Enum (`src/tree/node.rs`)
+
+Add two variants. Preserve Default at `Unknown`.
+
+| Variant | `label()` | `description()` | `url()` |
+|---------|-----------|------------------|---------|
+| `SwiftPm` | `"Swift Package Manager"` | `"Swift Package Manager — cached git clones, artifacts, and manifests"` | `"https://www.swift.org/package-manager/"` |
+| `Xcode` | `"Xcode"` | `"Xcode build caches — DerivedData, iOS DeviceSupport, Simulator"` | `"https://developer.apple.com/xcode/"` |
+
+## Config (`src/config.rs`)
+
+Add to `Config::default()`:
+
+```rust
+#[cfg(target_os = "macos")]
+{
+    let swiftpm = home.join("Library/Caches/org.swift.swiftpm");
+    if swiftpm.exists() {
+        roots.push(swiftpm);
+    }
+    let derived_data = home.join("Library/Developer/Xcode/DerivedData");
+    if derived_data.exists() {
+        roots.push(derived_data);
+    }
+    let device_support = home.join("Library/Developer/Xcode/iOS DeviceSupport");
+    if device_support.exists() {
+        roots.push(device_support);
+    }
+    let coresim_caches = home.join("Library/Developer/CoreSimulator/Caches");
+    if coresim_caches.exists() {
+        roots.push(coresim_caches);
+    }
+}
+
+// Linux SwiftPM path (macOS-only providers above; Linux users may still use SwiftPM)
+let swiftpm_linux = home.join(".cache/org.swift.swiftpm");
+if swiftpm_linux.exists() && !roots.iter().any(|r| r == &swiftpm_linux) {
+    roots.push(swiftpm_linux);
+}
+```
+
+No subprocess probing (no `probe_*_paths()`). All paths are static.
+
+`default_for_test()` is unaffected (it returns `roots: vec![]` regardless).
+
+A config test asserts the new roots appear when the directories exist; skips cleanly when they don't (CI without Xcode installed stays green).
+
+## UI Impact
+
+None. The tree view, detail panel, and deletion flow all work generically off `CacheKind`, `MetadataField`, and `SafetyLevel`. New providers slot in automatically.
+
+## Testing Strategy
+
+### Tier 1: Unit Tests (in-module, `#[cfg(test)]`)
+
+Hardcore TDD: every function gets a failing test before implementation. Tests live in `src/providers/swiftpm.rs` and `src/providers/xcode.rs`. Use `tempfile::tempdir()` for fixtures involving `Info.plist`.
+
+**SwiftPM tests (required):**
+- `detect_swiftpm_library_caches_root` (macOS path).
+- `detect_swiftpm_linux_cache_root`.
+- `detect_swiftpm_repositories_subdir`.
+- `detect_swiftpm_rejects_confusable_suffix` — path ending `org.swift.swiftpm-backup` must NOT detect as SwiftPm (L1).
+- `semantic_name_strips_hash_suffix_from_repository`.
+- `semantic_name_passes_through_artifacts_dir`.
+- `semantic_name_returns_none_for_manifests_file`.
+- `semantic_name_handles_non_ascii_package_name` (L2) — e.g. `café-a1b2c3d4`.
+- `package_id_always_none`.
+- `safety_repositories_is_caution`.
+- `safety_artifacts_is_safe`.
+- `safety_manifests_is_safe`.
+- `safety_rejects_confusable_suffix` — `org.swift.swiftpm/repositories-old/foo` must NOT be classified as Caution-repositories.
+
+**Xcode tests (required):**
+- `detect_xcode_derived_data`.
+- `detect_xcode_ios_device_support`.
+- `detect_xcode_core_simulator_caches`.
+- `detect_xcode_rejects_confusable_suffix` — `Xcode/DerivedData-backup/` must NOT detect (L1).
+- `semantic_name_derived_data_from_info_plist` — fixture `Info.plist` with `WORKSPACE_PATH=/Users/j/dev/MyApp/MyApp.xcworkspace` → `"MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)"`.
+- `semantic_name_derived_data_missing_plist_falls_back_to_dirname`.
+- `semantic_name_derived_data_malformed_plist_falls_back_to_dirname` — truncated XML must not panic.
+- `semantic_name_derived_data_non_ascii_workspace_path` (L2, L5) — `WORKSPACE_PATH` containing CJK characters renders correctly, no byte-boundary panic.
+- `semantic_name_ios_device_support_uses_dirname`.
+- `semantic_name_core_simulator_returns_none`.
+- `package_id_always_none`.
+- `safety_derived_data_is_caution`.
+- `safety_ios_device_support_is_safe`.
+- `safety_core_simulator_caches_is_safe`.
+- `safety_rejects_confusable_suffix` — `DerivedData-backup/` NOT classified as Caution-DerivedData.
+
+All tests must use `Config::default_for_test()` when a config is needed (L6 — no subprocess).
+
+### Tier 2: Integration Tests (`tests/integration.rs`)
+
+Extend existing integration test file (if the pattern fits) OR add a small file `tests/integration_swiftpm_xcode.rs`:
+
+- Build synthetic fixtures in tempdir: fake `org.swift.swiftpm/` with all three subdirs populated; fake `DerivedData/MyApp-abc/Info.plist` with known `WORKSPACE_PATH`.
+- Run `discover_packages()` and assert both providers' roots are walked.
+- Assert semantic names render correctly through the full pipeline.
+- Assert safety classification flows through to the detail panel's icon selection.
+
+### Tier 3: E2E Tests
+
+**Explicitly exempt.** Rationale documented in-module:
+
+- Neither provider participates in OSV or the version-check registry. The `feedback_e2e_full_pipeline` rubric ("install real tools, download outdated+vulnerable packages, verify OSV + version-check fire") describes a pipeline that does not apply here.
+- The disk-hygiene behavior is fully covered by Tier 1 (functional correctness on synthetic fixtures) + Tier 2 (full pipeline on synthetic fixtures).
+- Writing a synthetic-only E2E file would duplicate Tier 2 coverage under a different feature flag without adding signal.
+
+Each provider module starts with a short comment header noting this exemption and why, so a future reviewer comparing against `adding-a-provider.md` §2's E2E checkbox knows the decision was deliberate.
+
+## Docs Updates
+
+- `README.md` — add two rows to the Supported Caches table; bump provider count; add SwiftPM + Xcode to the "Why" rationale bullet if relevant.
+- `CHANGELOG.md` — `[Unreleased]` / `### Added` entries for both providers. Explicitly note: (a) SwiftPM's `c` upgrade key is a no-op by design; (b) neither provider runs OSV or version-check.
+- `docs/adding-a-provider.md` — append "Lessons learned" entry after the PR merges (§5): one line each for SwiftPM (package_id-skip rationale) and Xcode (Info.plist parsing as non-OSV signal source).
+- `TODO.md` — tick issue #11 and #17.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tree/node.rs` | Add `SwiftPm`, `Xcode` to `CacheKind` enum with label/description/url |
+| `src/providers/mod.rs` | Add `pub mod swiftpm; pub mod xcode;`; add match arms in `detect`, `semantic_name`, `metadata`, `safety` |
+| `src/providers/swiftpm.rs` | **New** — SwiftPM provider |
+| `src/providers/xcode.rs` | **New** — Xcode/DerivedData provider |
+| `src/config.rs` | Add default roots for both providers (macOS + Linux SwiftPM), with `exists()` guards |
+| `tests/integration_swiftpm_xcode.rs` | **New** (or extend existing) — synthetic fixture pipeline tests |
+| `README.md` | Update Supported Caches table + count |
+| `CHANGELOG.md` | `[Unreleased]` entries noting OSV/version-check exemption |
+| `docs/adding-a-provider.md` | Append Lessons learned lines after merge |
+| `TODO.md` | Tick #11 and #17 |
+
+## Out of Scope
+
+- SwiftPM `package_id` / OSV / version-check integration (future PR once OSV `SwiftURL` coverage justifies it).
+- Parsing Xcode's `Info.plist` binary variant (we observe only XML in practice; will revisit if a user reports binary-plist output).
+- Distinguishing active vs stale DerivedData projects (would require correlating with disk-present workspace files — out of scope for disk hygiene).
+- Linux Xcode provider support (Xcode is Apple-only; we scope the `#[cfg(target_os = "macos")]` block accordingly, but SwiftPM's Linux path IS included).
+- Detecting `~/Library/Developer/CoreSimulator/Devices/` (this contains active simulator state and user data — deleting breaks users' simulator setups; explicitly excluded as unsafe).
+
+## Risks
+
+- **Info.plist format drift:** If Apple ever switches DerivedData's `Info.plist` to binary format, XML string-search parsing returns `None`, and we fall back to the directory name. No crash, just degraded semantic names. Acceptable.
+- **SwiftPM layout change:** The `repositories/`, `artifacts/`, `manifests/` triad is stable as of Swift 5.9, but SwiftPM is evolving. Unknown future subdirs get `Caution` safety by default — conservative fail-safe.
+- **Hash suffix false positive:** A package legitimately ending in `-<8hex>` would have its hash stripped. Real-world hit rate is near zero; acceptable.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -128,9 +128,15 @@ When you select an item, the right panel shows:
 
 ### Scanning for Vulnerabilities
 
-Press **`V`** to scan all cached packages against the [OSV.dev](https://osv.dev) vulnerability database. This finds known CVEs in your pip, uv, npm, and Cargo cached packages.
+Press **`V`** to scan all cached packages against the [OSV.dev](https://osv.dev) vulnerability database. Press **`v`** (lowercase) to scan only the selected item and its children.
 
-Press **`v`** (lowercase) to scan only the selected item and its children.
+Participating providers (cover all package-manager ecosystems supported by OSV):
+- **pip**, **uv** → OSV `PyPI`
+- **npm**, **Yarn**, **pnpm**, **Bun** → OSV `npm`
+- **Cargo** → OSV `crates.io`
+- **Maven**, **Gradle** → OSV `Maven`
+
+Other providers (HuggingFace, Homebrew, Whisper, GitHub CLI, PyTorch, Chroma, Prisma, pre-commit, SwiftPM, Xcode) are disk-hygiene only — pressing `v`/`V` on entries from those providers is a no-op. See the [Provider Capabilities matrix](../README.md#provider-capabilities) in the README for the full list.
 
 The scan:
 1. Discovers packages with identifiable name + version across all caches
@@ -142,7 +148,15 @@ Results appear as `⚠` icons in the tree and detailed CVE info in the right pan
 
 ### Checking for Outdated Packages
 
-Press **`O`** to check all packages against their registries (PyPI, crates.io, npm). Press **`o`** for just the selected item.
+Press **`O`** to check all packages against their registries; **`o`** for just the selected item.
+
+Registries queried:
+- **pip**, **uv** → PyPI JSON API
+- **npm**, **Yarn**, **pnpm**, **Bun** → npm registry
+- **Cargo** → crates.io
+- **Maven**, **Gradle** → Maven Central (`maven-metadata.xml`, prefers `<release>` over `<latest>` to avoid SNAPSHOTs)
+
+Providers without a public registry (SwiftPM, Xcode, etc.) skip this step. See the README's Provider Capabilities matrix for the full list.
 
 Outdated packages show `↓` in the tree and "Update available" in the detail panel.
 
@@ -243,11 +257,27 @@ This deletes only the vulnerable cached artifacts. Next time your package manage
 
 ## Copying Upgrade Commands
 
-When viewing a vulnerable or outdated package, press **`c`** to copy the upgrade command to your clipboard:
+When viewing a vulnerable or outdated package, press **`c`** to copy the upgrade command to your clipboard.
 
-- pip/uv packages: `pip install requests>=2.32.0`
-- npm packages: `npm install express@4.19.0`
-- Cargo packages: `cargo update -p serde`
+Shell commands:
+- **pip** → `pip install 'requests>=2.32.0'`
+- **uv** → `uv pip install 'requests>=2.32.0'`
+- **npm** → `npm install express@4.19.0`
+- **Yarn** → `yarn add express@4.19.0`
+- **pnpm** → `pnpm add express@4.19.0`
+- **Bun** → `bun add express@4.19.0`
+- **Cargo** → `cargo update -p serde`
+
+Paste-ready snippets (JVM ecosystems have no single-line CLI upgrade):
+- **Maven** → `<dependency><groupId>…</groupId><artifactId>…</artifactId><version>…</version></dependency>`
+- **Gradle** → `implementation 'group:artifact:version'`
+
+Providers without upgrade commands (`c` is a no-op):
+- **SwiftPM** — upgrades are project-local (`swift package update`, `Package.swift`), not cache-entry operations.
+- **Xcode** — build artifacts, not packages.
+- **HuggingFace, Homebrew, Whisper, GitHub CLI, PyTorch, Chroma, Prisma, pre-commit** — no package-manager ecosystem wired up.
+
+See the [Provider Capabilities matrix](../README.md#provider-capabilities) for the full list.
 
 If clipboard access isn't available, the command is shown in the status bar.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,13 +144,15 @@ impl Default for Config {
             roots.push(gradle_caches);
         }
 
-        // SwiftPM + Xcode caches (mostly macOS-only; SwiftPM has a Linux path).
+        // Xcode caches live outside ~/Library/Caches, so they need their
+        // own roots. SwiftPM deliberately does NOT get its own root —
+        // its cache (org.swift.swiftpm) lives under ~/Library/Caches on
+        // macOS and ~/.cache on Linux, both already configured above.
+        // Adding it as a duplicate root would create two TreeNodes for
+        // the same path, breaking child expansion (insert_children
+        // matches via first position()).
         #[cfg(target_os = "macos")]
         {
-            let swiftpm = home.join("Library/Caches/org.swift.swiftpm");
-            if swiftpm.exists() {
-                roots.push(swiftpm);
-            }
             let derived_data = home.join("Library/Developer/Xcode/DerivedData");
             if derived_data.exists() {
                 roots.push(derived_data);
@@ -162,13 +164,6 @@ impl Default for Config {
             let coresim_caches = home.join("Library/Developer/CoreSimulator/Caches");
             if coresim_caches.exists() {
                 roots.push(coresim_caches);
-            }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            let swiftpm_linux = home.join(".cache/org.swift.swiftpm");
-            if swiftpm_linux.exists() && !roots.contains(&swiftpm_linux) {
-                roots.push(swiftpm_linux);
             }
         }
 
@@ -837,15 +832,33 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn default_config_includes_swiftpm_on_macos_when_exists() {
+    fn default_config_does_not_add_swiftpm_as_separate_root_on_macos() {
+        // SwiftPM's cache lives at ~/Library/Caches/org.swift.swiftpm,
+        // which is already under the ~/Library/Caches root. Adding it as
+        // a duplicate root creates two TreeNodes with the same path —
+        // insert_children picks the first one by position() and the
+        // user's expand on the root-level duplicate silently does
+        // nothing. Discovery via the parent root is sufficient;
+        // detect() classifies org.swift.swiftpm correctly on the first
+        // level-down expand.
         let swiftpm = dirs_home().join("Library/Caches/org.swift.swiftpm");
-        if !swiftpm.exists() {
-            return; // graceful skip on CI / hosts without SwiftPM
-        }
         let config = Config::default();
         assert!(
-            config.roots.iter().any(|r| r == &swiftpm),
-            "expected SwiftPM root in config, got {:?}",
+            !config.roots.iter().any(|r| r == &swiftpm),
+            "SwiftPM must not be listed as its own root, got {:?}",
+            config.roots
+        );
+    }
+
+    #[test]
+    fn default_config_does_not_add_swiftpm_as_separate_root_on_linux() {
+        // Same rationale as the macOS test — ~/.cache/org.swift.swiftpm
+        // lives under the ~/.cache root.
+        let swiftpm = dirs_home().join(".cache/org.swift.swiftpm");
+        let config = Config::default();
+        assert!(
+            !config.roots.iter().any(|r| r == &swiftpm),
+            "SwiftPM must not be listed as its own root on Linux, got {:?}",
             config.roots
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,34 @@ impl Default for Config {
             roots.push(gradle_caches);
         }
 
+        // SwiftPM + Xcode caches (mostly macOS-only; SwiftPM has a Linux path).
+        #[cfg(target_os = "macos")]
+        {
+            let swiftpm = home.join("Library/Caches/org.swift.swiftpm");
+            if swiftpm.exists() {
+                roots.push(swiftpm);
+            }
+            let derived_data = home.join("Library/Developer/Xcode/DerivedData");
+            if derived_data.exists() {
+                roots.push(derived_data);
+            }
+            let device_support = home.join("Library/Developer/Xcode/iOS DeviceSupport");
+            if device_support.exists() {
+                roots.push(device_support);
+            }
+            let coresim_caches = home.join("Library/Developer/CoreSimulator/Caches");
+            if coresim_caches.exists() {
+                roots.push(coresim_caches);
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let swiftpm_linux = home.join(".cache/org.swift.swiftpm");
+            if swiftpm_linux.exists() && !roots.contains(&swiftpm_linux) {
+                roots.push(swiftpm_linux);
+            }
+        }
+
         // Yarn cache paths
         for path in probe_yarn_paths() {
             if !roots.contains(&path) {
@@ -795,5 +823,75 @@ mod tests {
     fn cli_mcp_subcommand_parses() {
         let cli = Cli::try_parse_from(["ccmd", "mcp"]).unwrap();
         assert!(cli.command.is_some());
+    }
+
+    // --- SwiftPM / Xcode default roots ---
+
+    #[test]
+    fn default_for_test_is_empty_roots() {
+        // Regression guard: adding new roots must not leak into the test
+        // config (L6). If this fails, default_for_test() was quietly
+        // extended to probe the host — don't do that.
+        assert!(Config::default_for_test().roots.is_empty());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_config_includes_swiftpm_on_macos_when_exists() {
+        let swiftpm = dirs_home().join("Library/Caches/org.swift.swiftpm");
+        if !swiftpm.exists() {
+            return; // graceful skip on CI / hosts without SwiftPM
+        }
+        let config = Config::default();
+        assert!(
+            config.roots.iter().any(|r| r == &swiftpm),
+            "expected SwiftPM root in config, got {:?}",
+            config.roots
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_config_includes_derived_data_when_exists() {
+        let dd = dirs_home().join("Library/Developer/Xcode/DerivedData");
+        if !dd.exists() {
+            return;
+        }
+        let config = Config::default();
+        assert!(
+            config.roots.iter().any(|r| r == &dd),
+            "expected DerivedData root, got {:?}",
+            config.roots
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_config_includes_ios_device_support_when_exists() {
+        let ds = dirs_home().join("Library/Developer/Xcode/iOS DeviceSupport");
+        if !ds.exists() {
+            return;
+        }
+        let config = Config::default();
+        assert!(
+            config.roots.iter().any(|r| r == &ds),
+            "expected iOS DeviceSupport root, got {:?}",
+            config.roots
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn default_config_includes_coresimulator_caches_when_exists() {
+        let sim = dirs_home().join("Library/Developer/CoreSimulator/Caches");
+        if !sim.exists() {
+            return;
+        }
+        let config = Config::default();
+        assert!(
+            config.roots.iter().any(|r| r == &sim),
+            "expected CoreSimulator/Caches root, got {:?}",
+            config.roots
+        );
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -379,6 +379,17 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
             // Path is the root itself or outside the known layout.
             SafetyLevel::Caution
         }
+        CacheKind::Xcode => {
+            // Only DerivedData triggers Caution (rebuild cost). iOS
+            // DeviceSupport and CoreSimulator caches are Safe. Component
+            // matching avoids L1 substring leaks (DerivedData-backup stays
+            // on the Safe fall-through).
+            if has_adjacent_components(path, "Xcode", "DerivedData") {
+                SafetyLevel::Caution
+            } else {
+                SafetyLevel::Safe
+            }
+        }
         CacheKind::Unknown => SafetyLevel::Caution,
         _ => SafetyLevel::Safe,
     }
@@ -1546,5 +1557,33 @@ mod tests {
             safety(CacheKind::SwiftPm, &confusable),
             SafetyLevel::Caution
         );
+    }
+
+    // --- Xcode safety ---
+
+    #[test]
+    fn safety_xcode_derived_data_is_caution() {
+        let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData/MyApp-abc");
+        assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Caution);
+    }
+
+    #[test]
+    fn safety_xcode_ios_device_support_is_safe() {
+        let path =
+            PathBuf::from("/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)");
+        assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_xcode_core_simulator_caches_is_safe() {
+        let path = PathBuf::from("/Users/j/Library/Developer/CoreSimulator/Caches/something");
+        assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_xcode_rejects_confusable_suffix_derived_data() {
+        // L1: DerivedData-backup must not be classified as Caution-DerivedData.
+        let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData-backup/junk");
+        assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,9 +12,11 @@ pub mod pip;
 pub mod pnpm;
 pub mod pre_commit;
 pub mod prisma;
+pub mod swiftpm;
 pub mod torch;
 pub mod uv;
 pub mod whisper;
+pub mod xcode;
 pub mod yarn;
 
 use crate::tree::node::CacheKind;
@@ -78,6 +80,7 @@ pub fn detect(path: &Path) -> CacheKind {
         ".pnpm" => return CacheKind::Pnpm,
         ".m2" => return CacheKind::Maven,
         ".gradle" => return CacheKind::Gradle,
+        "org.swift.swiftpm" => return CacheKind::SwiftPm,
         _ => {}
     }
 
@@ -132,8 +135,20 @@ pub fn detect(path: &Path) -> CacheKind {
             "registry" if ancestor.to_string_lossy().contains(".cargo") => {
                 return CacheKind::Cargo;
             }
+            "org.swift.swiftpm" => return CacheKind::SwiftPm,
             _ => {}
         }
+    }
+
+    // Xcode detection uses adjacent-component matching (L1-safe) rather
+    // than single-component ancestor walks, because names like
+    // "DerivedData" or "Caches" alone are too ambiguous to match
+    // unconditionally.
+    if has_adjacent_components(path, "Xcode", "DerivedData")
+        || has_adjacent_components(path, "Xcode", "iOS DeviceSupport")
+        || has_adjacent_components(path, "CoreSimulator", "Caches")
+    {
+        return CacheKind::Xcode;
     }
 
     CacheKind::Unknown
@@ -159,6 +174,8 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Bun => bun::semantic_name(path),
         CacheKind::Maven => maven::semantic_name(path),
         CacheKind::Gradle => gradle::semantic_name(path),
+        CacheKind::SwiftPm => swiftpm::semantic_name(path),
+        CacheKind::Xcode => xcode::semantic_name(path),
         CacheKind::Unknown => None,
     }
 }
@@ -183,6 +200,8 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Bun => bun::metadata(path),
         CacheKind::Maven => maven::metadata(path),
         CacheKind::Gradle => gradle::metadata(path),
+        CacheKind::SwiftPm => swiftpm::metadata(path),
+        CacheKind::Xcode => xcode::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
 }
@@ -1355,6 +1374,8 @@ mod tests {
             CacheKind::Bun,
             CacheKind::Maven,
             CacheKind::Gradle,
+            CacheKind::SwiftPm,
+            CacheKind::Xcode,
             CacheKind::Unknown,
         ];
         for kind in &all {
@@ -1364,5 +1385,106 @@ mod tests {
             let _ = metadata(*kind, &dummy);
             let _ = package_id(*kind, &dummy);
         }
+    }
+
+    // --- SwiftPM detect ---
+
+    #[test]
+    fn detect_swiftpm_library_caches_root() {
+        assert_eq!(
+            detect(&PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm")),
+            CacheKind::SwiftPm
+        );
+    }
+
+    #[test]
+    fn detect_swiftpm_linux_cache_root() {
+        assert_eq!(
+            detect(&PathBuf::from("/home/u/.cache/org.swift.swiftpm")),
+            CacheKind::SwiftPm
+        );
+    }
+
+    #[test]
+    fn detect_swiftpm_repositories_subdir() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234"
+            )),
+            CacheKind::SwiftPm
+        );
+    }
+
+    #[test]
+    fn detect_swiftpm_rejects_confusable_suffix() {
+        // L1: substring match would accept this; component match must reject.
+        assert_ne!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Caches/org.swift.swiftpm-backup"
+            )),
+            CacheKind::SwiftPm
+        );
+    }
+
+    // --- Xcode detect ---
+
+    #[test]
+    fn detect_xcode_derived_data() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Developer/Xcode/DerivedData"
+            )),
+            CacheKind::Xcode
+        );
+    }
+
+    #[test]
+    fn detect_xcode_derived_data_project_subdir() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Developer/Xcode/DerivedData/MyApp-abc123def456"
+            )),
+            CacheKind::Xcode
+        );
+    }
+
+    #[test]
+    fn detect_xcode_ios_device_support() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)"
+            )),
+            CacheKind::Xcode
+        );
+    }
+
+    #[test]
+    fn detect_xcode_core_simulator_caches() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Developer/CoreSimulator/Caches/something"
+            )),
+            CacheKind::Xcode
+        );
+    }
+
+    #[test]
+    fn detect_xcode_rejects_confusable_suffix() {
+        // L1: Xcode/DerivedData-backup must not match.
+        assert_ne!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Developer/Xcode/DerivedData-backup"
+            )),
+            CacheKind::Xcode
+        );
+    }
+
+    #[test]
+    fn detect_xcode_rejects_unrelated_derived_data() {
+        // A DerivedData directory not under Xcode must not match.
+        assert_ne!(
+            detect(&PathBuf::from("/random/path/DerivedData")),
+            CacheKind::Xcode
+        );
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -363,6 +363,22 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
                 SafetyLevel::Safe
             }
         }
+        CacheKind::SwiftPm => {
+            // Walk the adjacent component after `org.swift.swiftpm` to decide.
+            // Component-based match avoids L1 substring false positives.
+            let comps: Vec<&std::ffi::OsStr> = path.components().map(|c| c.as_os_str()).collect();
+            for w in comps.windows(2) {
+                if w[0] == "org.swift.swiftpm" {
+                    return match w[1].to_string_lossy().as_ref() {
+                        "repositories" => SafetyLevel::Caution,
+                        "artifacts" | "manifests" => SafetyLevel::Safe,
+                        _ => SafetyLevel::Caution, // unknown future subdirs
+                    };
+                }
+            }
+            // Path is the root itself or outside the known layout.
+            SafetyLevel::Caution
+        }
         CacheKind::Unknown => SafetyLevel::Caution,
         _ => SafetyLevel::Safe,
     }
@@ -1485,6 +1501,50 @@ mod tests {
         assert_ne!(
             detect(&PathBuf::from("/random/path/DerivedData")),
             CacheKind::Xcode
+        );
+    }
+
+    // --- SwiftPM safety ---
+
+    #[test]
+    fn safety_swiftpm_repositories_is_caution() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+        );
+        assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Caution);
+    }
+
+    #[test]
+    fn safety_swiftpm_artifacts_is_safe() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/artifacts/MyBinaryDep");
+        assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_swiftpm_manifests_is_safe() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/manifests/deadbeef");
+        assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_swiftpm_unknown_subdir_is_caution() {
+        // Conservative: unknown future subdir defaults to Caution.
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/futuredir/item");
+        assert_eq!(safety(CacheKind::SwiftPm, &path), SafetyLevel::Caution);
+    }
+
+    #[test]
+    fn safety_swiftpm_rejects_confusable_suffix() {
+        // L1: `repositories-old` must NOT be classified as repositories Caution —
+        // it falls through to the unknown-subdir Caution default, which happens
+        // to also be Caution, so assert the classification path via a Safe
+        // companion check.
+        let confusable =
+            PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/artifacts-backup/MyDep");
+        // artifacts-backup must NOT be Safe (it isn't artifacts/).
+        assert_eq!(
+            safety(CacheKind::SwiftPm, &confusable),
+            SafetyLevel::Caution
         );
     }
 }

--- a/src/providers/swiftpm.rs
+++ b/src/providers/swiftpm.rs
@@ -53,8 +53,31 @@ fn strip_hash_suffix(s: &str) -> String {
     }
 }
 
-pub fn metadata(_path: &Path) -> Vec<MetadataField> {
-    Vec::new()
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent_is_swiftpm_root = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .is_some_and(|n| n == "org.swift.swiftpm");
+    if parent_is_swiftpm_root {
+        let value = match name.as_str() {
+            "repositories" => Some("Git clones of package sources (re-cloneable)"),
+            "artifacts" => Some("Binary artifacts (re-downloadable)"),
+            "manifests" => Some("Cached Package.swift resolutions"),
+            _ => None,
+        };
+        if let Some(v) = value {
+            fields.push(MetadataField {
+                label: "Contents".to_string(),
+                value: v.to_string(),
+            });
+        }
+    }
+    fields
 }
 
 #[cfg(test)]
@@ -115,5 +138,49 @@ mod tests {
         let path =
             PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/repositories/plain-name");
         assert_eq!(semantic_name(&path), Some("plain-name".into()));
+    }
+
+    #[test]
+    fn metadata_repositories_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/repositories");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Git clones")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_artifacts_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/artifacts");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Binary artifacts")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_manifests_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/manifests");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Package.swift")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_leaf_file_returns_empty() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+        );
+        assert!(metadata(&path).is_empty());
     }
 }

--- a/src/providers/swiftpm.rs
+++ b/src/providers/swiftpm.rs
@@ -9,10 +9,111 @@
 use super::MetadataField;
 use std::path::Path;
 
-pub fn semantic_name(_path: &Path) -> Option<String> {
-    None
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Skip the three known subdir roots themselves — tree renders them
+    // literally.
+    if matches!(name.as_str(), "repositories" | "artifacts" | "manifests") {
+        return None;
+    }
+
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    match parent_name.as_str() {
+        "repositories" => Some(strip_hash_suffix(&name)),
+        "artifacts" => Some(name),
+        // manifests/ holds files whose names are internal hashes — no
+        // meaningful display, fall back to raw file name via None (tree
+        // shows the basename anyway).
+        "manifests" => None,
+        _ => None,
+    }
+}
+
+/// Strip a trailing `-<hex>` where hex is 7 or more lowercase-hex chars.
+/// Returns the input unchanged if no such suffix exists.
+fn strip_hash_suffix(s: &str) -> String {
+    let Some(dash_idx) = s.rfind('-') else {
+        return s.to_string();
+    };
+    let suffix = &s[dash_idx + 1..];
+    if suffix.len() >= 7
+        && suffix
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        s[..dash_idx].to_string()
+    } else {
+        s.to_string()
+    }
 }
 
 pub fn metadata(_path: &Path) -> Vec<MetadataField> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn semantic_name_strips_hash_suffix_from_repository() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-collections-abc1234",
+        );
+        assert_eq!(semantic_name(&path), Some("swift-collections".into()));
+    }
+
+    #[test]
+    fn semantic_name_strips_long_hash_suffix() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Caches/org.swift.swiftpm/repositories/swift-nio-0123456789abcdef",
+        );
+        assert_eq!(semantic_name(&path), Some("swift-nio".into()));
+    }
+
+    #[test]
+    fn semantic_name_passes_through_artifacts_dir() {
+        let path = PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/artifacts/MyBinaryDep");
+        assert_eq!(semantic_name(&path), Some("MyBinaryDep".into()));
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_manifests_file() {
+        // manifest filenames are internal hashes; no meaningful display.
+        let path =
+            PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/manifests/deadbeef1234");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_known_subdir_roots() {
+        for subdir in ["repositories", "artifacts", "manifests"] {
+            let path = PathBuf::from(format!(
+                "/Users/j/Library/Caches/org.swift.swiftpm/{subdir}"
+            ));
+            assert_eq!(semantic_name(&path), None, "{subdir}");
+        }
+    }
+
+    #[test]
+    fn semantic_name_handles_non_ascii_package_name() {
+        // L2: no byte-boundary panic on multi-byte package names.
+        let path =
+            PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/repositories/café-abc1234");
+        assert_eq!(semantic_name(&path), Some("café".into()));
+    }
+
+    #[test]
+    fn semantic_name_falls_back_to_dirname_without_hash_suffix() {
+        let path =
+            PathBuf::from("/Users/j/Library/Caches/org.swift.swiftpm/repositories/plain-name");
+        assert_eq!(semantic_name(&path), Some("plain-name".into()));
+    }
 }

--- a/src/providers/swiftpm.rs
+++ b/src/providers/swiftpm.rs
@@ -1,0 +1,18 @@
+// SwiftPM provider.
+//
+// No `package_id` / `upgrade_command` arms — SwiftPM's package identity
+// requires git-ref parsing that is too brittle for v1, and there's no
+// public registry for version lookups. OSV `SwiftURL` coverage is
+// sparse. Tier-3 E2E tests are intentionally exempt (see design spec
+// 2026-04-20-swiftpm-xcode-providers-design.md).
+
+use super::MetadataField;
+use std::path::Path;
+
+pub fn semantic_name(_path: &Path) -> Option<String> {
+    None
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}

--- a/src/providers/xcode.rs
+++ b/src/providers/xcode.rs
@@ -1,0 +1,16 @@
+// Xcode provider (DerivedData, iOS DeviceSupport, CoreSimulator Caches).
+//
+// No package identity / OSV / version-check / upgrade-command: these are
+// build artifacts, not packages. Tier-3 E2E tests intentionally exempt
+// (see design spec 2026-04-20-swiftpm-xcode-providers-design.md).
+
+use super::MetadataField;
+use std::path::Path;
+
+pub fn semantic_name(_path: &Path) -> Option<String> {
+    None
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}

--- a/src/providers/xcode.rs
+++ b/src/providers/xcode.rs
@@ -7,10 +7,164 @@
 use super::MetadataField;
 use std::path::Path;
 
-pub fn semantic_name(_path: &Path) -> Option<String> {
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Known root subdirs — let the tree render them literally.
+    if matches!(
+        name.as_str(),
+        "DerivedData" | "iOS DeviceSupport" | "Caches"
+    ) {
+        return None;
+    }
+
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if parent_name == "DerivedData" {
+        if let Some(workspace_path) = read_workspace_path(path) {
+            let basename = workspace_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(&workspace_path)
+                .to_string();
+            return Some(format!("{basename} (at {workspace_path})"));
+        }
+        return Some(name);
+    }
+
+    if parent_name == "iOS DeviceSupport" {
+        return Some(name);
+    }
+
+    // CoreSimulator/Caches entries: opaque, no semantic name.
     None
+}
+
+/// Read `WORKSPACE_PATH` from `Info.plist` (XML variant).
+/// Returns None on any failure (missing file, malformed XML, missing key).
+fn read_workspace_path(dir: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(dir.join("Info.plist")).ok()?;
+    extract_plist_string(&content, "WORKSPACE_PATH")
+}
+
+/// Extract a string value by key from an XML plist body. Avoids a
+/// `plist` crate dependency — Xcode consistently emits XML for
+/// DerivedData Info.plist. Uses only char-boundary-safe string APIs
+/// (`find`, `str` slicing by returned byte indices) so multi-byte
+/// content does not panic (L2, L5).
+fn extract_plist_string(xml: &str, key: &str) -> Option<String> {
+    let key_tag = format!("<key>{key}</key>");
+    let key_pos = xml.find(&key_tag)?;
+    let after_key = &xml[key_pos + key_tag.len()..];
+    let open = "<string>";
+    let open_pos = after_key.find(open)?;
+    let value_start = open_pos + open.len();
+    let close_pos = after_key[value_start..].find("</string>")?;
+    let value = &after_key[value_start..value_start + close_pos];
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
 }
 
 pub fn metadata(_path: &Path) -> Vec<MetadataField> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_derived_data_dir(tmp: &TempDir, workspace_path: Option<&str>) -> PathBuf {
+        let root = tmp
+            .path()
+            .join("Library/Developer/Xcode/DerivedData/MyApp-abc123def");
+        std::fs::create_dir_all(&root).unwrap();
+        if let Some(wp) = workspace_path {
+            let plist = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>WORKSPACE_PATH</key>
+    <string>{wp}</string>
+</dict>
+</plist>"#
+            );
+            std::fs::write(root.join("Info.plist"), plist).unwrap();
+        }
+        root
+    }
+
+    #[test]
+    fn semantic_name_derived_data_from_info_plist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, Some("/Users/j/dev/MyApp/MyApp.xcworkspace"));
+        assert_eq!(
+            semantic_name(&dir),
+            Some("MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_derived_data_missing_plist_falls_back_to_dirname() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, None);
+        assert_eq!(semantic_name(&dir), Some("MyApp-abc123def".into()));
+    }
+
+    #[test]
+    fn semantic_name_derived_data_malformed_plist_falls_back_to_dirname() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp
+            .path()
+            .join("Library/Developer/Xcode/DerivedData/Broken-xyz");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("Info.plist"), "<plist><incomplete").unwrap();
+        assert_eq!(semantic_name(&root), Some("Broken-xyz".into()));
+    }
+
+    #[test]
+    fn semantic_name_derived_data_non_ascii_workspace_path() {
+        // L2 / L5: multi-byte chars in workspace path must not panic.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, Some("/Users/j/日本語/App.xcworkspace"));
+        assert_eq!(
+            semantic_name(&dir),
+            Some("App.xcworkspace (at /Users/j/日本語/App.xcworkspace)".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_ios_device_support_uses_dirname() {
+        let path =
+            PathBuf::from("/Users/j/Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)");
+        assert_eq!(semantic_name(&path), Some("17.4 (21E213)".into()));
+    }
+
+    #[test]
+    fn semantic_name_core_simulator_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/Library/Developer/CoreSimulator/Caches/com.apple.SimulatorTrampoline",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_known_roots_return_none() {
+        for p in [
+            "/Users/j/Library/Developer/Xcode/DerivedData",
+            "/Users/j/Library/Developer/Xcode/iOS DeviceSupport",
+            "/Users/j/Library/Developer/CoreSimulator/Caches",
+        ] {
+            assert_eq!(semantic_name(&PathBuf::from(p)), None, "{p}");
+        }
+    }
 }

--- a/src/providers/xcode.rs
+++ b/src/providers/xcode.rs
@@ -72,8 +72,58 @@ fn extract_plist_string(xml: &str, key: &str) -> Option<String> {
     }
 }
 
-pub fn metadata(_path: &Path) -> Vec<MetadataField> {
-    Vec::new()
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Root-level labels.
+    match name.as_str() {
+        "DerivedData" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Xcode build products and indexes (rebuildable, 5–30 min cost)".into(),
+            });
+            return fields;
+        }
+        "iOS DeviceSupport" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value:
+                    "Symbol files for connected iOS devices (re-downloadable on device reconnect)"
+                        .into(),
+            });
+            return fields;
+        }
+        "Caches" if parent_name == "CoreSimulator" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "iOS Simulator caches (safe to clear)".into(),
+            });
+            return fields;
+        }
+        _ => {}
+    }
+
+    // DerivedData project dir: surface WORKSPACE_PATH so the user sees
+    // which project they're about to nuke.
+    if parent_name == "DerivedData"
+        && let Some(wp) = read_workspace_path(path)
+    {
+        fields.push(MetadataField {
+            label: "Workspace".into(),
+            value: wp,
+        });
+    }
+
+    fields
 }
 
 #[cfg(test)]
@@ -166,5 +216,61 @@ mod tests {
         ] {
             assert_eq!(semantic_name(&PathBuf::from(p)), None, "{p}");
         }
+    }
+
+    #[test]
+    fn metadata_derived_data_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("build products")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_ios_device_support_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Developer/Xcode/iOS DeviceSupport");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Symbol files")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_core_simulator_caches_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Developer/CoreSimulator/Caches");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Simulator")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_derived_data_project_dir_emits_workspace_path_when_available() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, Some("/Users/j/dev/MyApp/MyApp.xcworkspace"));
+        let fields = metadata(&dir);
+        assert!(
+            fields.iter().any(
+                |f| f.label == "Workspace" && f.value == "/Users/j/dev/MyApp/MyApp.xcworkspace"
+            ),
+            "expected Workspace field, got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_derived_data_project_dir_without_plist_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = make_derived_data_dir(&tmp, None);
+        assert!(metadata(&dir).is_empty());
     }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -20,6 +20,8 @@ pub enum CacheKind {
     Bun,
     Maven,
     Gradle,
+    SwiftPm,
+    Xcode,
     #[default]
     Unknown,
 }
@@ -44,6 +46,8 @@ impl CacheKind {
             Self::Bun => "Bun",
             Self::Maven => "Maven",
             Self::Gradle => "Gradle",
+            Self::SwiftPm => "Swift Package Manager",
+            Self::Xcode => "Xcode",
             Self::Unknown => "",
         }
     }
@@ -71,6 +75,8 @@ impl CacheKind {
             Self::Gradle => {
                 "JVM build tool — dependency cache, wrapper distributions, and build cache"
             }
+            Self::SwiftPm => "Swift Package Manager — cached git clones, artifacts, and manifests",
+            Self::Xcode => "Xcode build caches — DerivedData, iOS DeviceSupport, Simulator",
             Self::Unknown => "",
         }
     }
@@ -94,6 +100,8 @@ impl CacheKind {
             Self::Bun => "https://bun.sh",
             Self::Maven => "https://maven.apache.org",
             Self::Gradle => "https://gradle.org",
+            Self::SwiftPm => "https://www.swift.org/package-manager/",
+            Self::Xcode => "https://developer.apple.com/xcode/",
             Self::Unknown => "",
         }
     }
@@ -248,6 +256,8 @@ mod tests {
             CacheKind::Bun,
             CacheKind::Maven,
             CacheKind::Gradle,
+            CacheKind::SwiftPm,
+            CacheKind::Xcode,
         ];
         for kind in &all {
             assert!(!kind.label().is_empty(), "{:?} label empty", kind);
@@ -275,5 +285,22 @@ mod tests {
         assert_eq!(CacheKind::Pnpm.label(), "pnpm");
         assert!(!CacheKind::Pnpm.description().is_empty());
         assert!(!CacheKind::Pnpm.url().is_empty());
+    }
+
+    #[test]
+    fn cache_kind_swiftpm_label_description_url() {
+        assert_eq!(CacheKind::SwiftPm.label(), "Swift Package Manager");
+        assert!(!CacheKind::SwiftPm.description().is_empty());
+        assert_eq!(
+            CacheKind::SwiftPm.url(),
+            "https://www.swift.org/package-manager/"
+        );
+    }
+
+    #[test]
+    fn cache_kind_xcode_label_description_url() {
+        assert_eq!(CacheKind::Xcode.label(), "Xcode");
+        assert!(!CacheKind::Xcode.description().is_empty());
+        assert_eq!(CacheKind::Xcode.url(), "https://developer.apple.com/xcode/");
     }
 }

--- a/tests/integration_swiftpm_xcode.rs
+++ b/tests/integration_swiftpm_xcode.rs
@@ -1,0 +1,130 @@
+// Integration test: synthetic SwiftPM + Xcode cache fixtures exercise the
+// full detect → semantic_name → metadata → safety pipeline.
+//
+// Tier-3 E2E exempt per design spec: neither provider participates in
+// OSV / version-check, so the standard "install tool, download
+// vulnerable package" rubric does not apply. Tier 1 (in-module unit
+// tests) + this Tier 2 integration test cover the disk-hygiene
+// behavior end to end.
+
+use ccmd::providers::{self, SafetyLevel};
+use ccmd::tree::node::CacheKind;
+use std::fs;
+
+#[test]
+fn swiftpm_fixture_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("Library/Caches/org.swift.swiftpm");
+    let repo = root.join("repositories/swift-collections-abc1234");
+    let artifact = root.join("artifacts/MyBinaryDep");
+    let manifest_dir = root.join("manifests");
+    let manifest = manifest_dir.join("deadbeef12345");
+    fs::create_dir_all(&repo).unwrap();
+    fs::create_dir_all(&artifact).unwrap();
+    fs::create_dir_all(&manifest_dir).unwrap();
+    fs::write(&manifest, b"").unwrap();
+
+    // detect
+    assert_eq!(providers::detect(&root), CacheKind::SwiftPm);
+    assert_eq!(providers::detect(&repo), CacheKind::SwiftPm);
+    assert_eq!(providers::detect(&manifest), CacheKind::SwiftPm);
+
+    // semantic_name
+    assert_eq!(
+        providers::semantic_name(CacheKind::SwiftPm, &repo),
+        Some("swift-collections".into())
+    );
+    assert_eq!(
+        providers::semantic_name(CacheKind::SwiftPm, &artifact),
+        Some("MyBinaryDep".into())
+    );
+    assert_eq!(
+        providers::semantic_name(CacheKind::SwiftPm, &manifest),
+        None
+    );
+
+    // metadata surfaces Contents on the known roots
+    let repos_root = root.join("repositories");
+    assert!(
+        providers::metadata(CacheKind::SwiftPm, &repos_root)
+            .iter()
+            .any(|f| f.label == "Contents"),
+        "expected Contents metadata on repositories/"
+    );
+
+    // safety
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &repo),
+        SafetyLevel::Caution
+    );
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &artifact),
+        SafetyLevel::Safe
+    );
+    assert_eq!(
+        providers::safety(CacheKind::SwiftPm, &manifest),
+        SafetyLevel::Safe
+    );
+}
+
+#[test]
+fn xcode_fixture_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dd = tmp
+        .path()
+        .join("Library/Developer/Xcode/DerivedData/MyApp-abc123def");
+    fs::create_dir_all(&dd).unwrap();
+    let plist = r#"<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>WORKSPACE_PATH</key>
+    <string>/Users/j/dev/MyApp/MyApp.xcworkspace</string>
+</dict>
+</plist>"#;
+    fs::write(dd.join("Info.plist"), plist).unwrap();
+
+    let ds = tmp
+        .path()
+        .join("Library/Developer/Xcode/iOS DeviceSupport/17.4 (21E213)");
+    fs::create_dir_all(&ds).unwrap();
+
+    let sim = tmp
+        .path()
+        .join("Library/Developer/CoreSimulator/Caches/com.apple.Sim");
+    fs::create_dir_all(&sim).unwrap();
+
+    // detect recognises all three root subtrees.
+    assert_eq!(providers::detect(&dd), CacheKind::Xcode);
+    assert_eq!(providers::detect(&ds), CacheKind::Xcode);
+    assert_eq!(providers::detect(&sim), CacheKind::Xcode);
+
+    // semantic_name extracts WORKSPACE_PATH from Info.plist; falls back
+    // for DeviceSupport (dir name); returns None for opaque simulator
+    // caches.
+    assert_eq!(
+        providers::semantic_name(CacheKind::Xcode, &dd),
+        Some("MyApp.xcworkspace (at /Users/j/dev/MyApp/MyApp.xcworkspace)".into())
+    );
+    assert_eq!(
+        providers::semantic_name(CacheKind::Xcode, &ds),
+        Some("17.4 (21E213)".into())
+    );
+    assert_eq!(providers::semantic_name(CacheKind::Xcode, &sim), None);
+
+    // metadata: DerivedData project dir surfaces the workspace path.
+    let fields = providers::metadata(CacheKind::Xcode, &dd);
+    assert!(
+        fields
+            .iter()
+            .any(|f| f.label == "Workspace" && f.value == "/Users/j/dev/MyApp/MyApp.xcworkspace"),
+        "expected Workspace metadata, got {fields:?}"
+    );
+
+    // safety classifies DerivedData as Caution (rebuild cost); others Safe.
+    assert_eq!(
+        providers::safety(CacheKind::Xcode, &dd),
+        SafetyLevel::Caution
+    );
+    assert_eq!(providers::safety(CacheKind::Xcode, &ds), SafetyLevel::Safe);
+    assert_eq!(providers::safety(CacheKind::Xcode, &sim), SafetyLevel::Safe);
+}


### PR DESCRIPTION
## Summary

Two new macOS-centric cache providers, both disk-hygiene only (no OSV, no version-check, no upgrade command):

- **SwiftPM (#11)** — classifies `~/Library/Caches/org.swift.swiftpm` (macOS) / `~/.cache/org.swift.swiftpm` (Linux). `repositories/` = Caution (re-clone cost); `artifacts/` + `manifests/` = Safe. Repository dirs render with their trailing git-URL hash stripped (`swift-collections-a1b2c3d4` → `swift-collections`).
- **Xcode (#17)** — detects `~/Library/Developer/Xcode/DerivedData`, `~/Library/Developer/Xcode/iOS DeviceSupport`, and `~/Library/Developer/CoreSimulator/Caches`. DerivedData is Caution (rebuild takes 5–30 min); the other two are Safe. DerivedData project dirs surface the workspace path from `Info.plist` (WORKSPACE_PATH) in the detail panel so you know which project you're about to nuke.

Xcode DerivedData is often the single largest cache on macOS dev machines (50–200 GB is routine), which is the whole motivation for shipping this now.

## Intentional design calls

- **No `package_id` for either provider**, so OSV and version-check pipelines never fire. SwiftPM: identity in the on-disk `repositories/` layout requires git-ref parsing that is too brittle for v1; OSV `SwiftURL` coverage is sparse. Xcode: build artifacts aren't packages. Documented in the CHANGELOG and in module header comments.
- **No Tier-3 E2E tests** for either provider — the standard rubric (install tool, download outdated+vulnerable packages, verify OSV + version-check fire) has nothing to exercise. Coverage is Tier 1 (unit, in-module) + Tier 2 (synthetic-fixture integration).
- **SwiftPM does NOT get its own root** — its cache lives under `~/Library/Caches` (macOS) / `~/.cache` (Linux), both already configured. Adding a duplicate root caused silent expand failures (two TreeNodes with the same path, `insert_children` picks the first via `position()`). The provider still classifies the directory when discovered via the parent root. Xcode caches live outside any existing root so they DO get their own. Fix is the last commit — regression test included.

## What changed

- `src/tree/node.rs` — `CacheKind::SwiftPm` and `CacheKind::Xcode` with label/description/url.
- `src/providers/mod.rs` — dispatch arms for `detect`, `semantic_name`, `metadata`, `safety`.
- `src/providers/swiftpm.rs` — new provider. Hash-suffix stripping, root-subdir detection, component-based safety classification.
- `src/providers/xcode.rs` — new provider. Info.plist WORKSPACE_PATH extraction via string-scanner (no `plist` crate dependency; char-boundary-safe for CJK paths).
- `src/config.rs` — Xcode roots auto-discovered via `exists()` guards. SwiftPM explicitly NOT added (see design call above).
- `tests/integration_swiftpm_xcode.rs` — Tier-2 synthetic-fixture pipeline tests.
- `README.md` — new Provider Capabilities matrix documenting what each of the 19 providers supports (safety, vuln scan, outdated check, upgrade copy) with SwiftPM/Xcode footnotes explaining the disk-hygiene-only design.
- `docs/user-guide.md` — security-scanning + upgrade-command sections now list participating providers instead of the stale "pip, uv, npm, Cargo" shorthand.
- `CHANGELOG.md`, `TODO.md`, `docs/adding-a-provider.md` — lessons learned, changelog, TODO ticks.

## Test plan

- [x] `cargo test` — 1850 passed
- [x] `cargo test --features mcp` — 1892 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] L1 confusable-suffix guards on both providers (`org.swift.swiftpm-backup`, `DerivedData-backup`)
- [x] L2 non-ASCII path guards (`café-<hash>` repository name, `日本語` workspace path)
- [x] Manual smoke: ran against real `~/Library/Caches/org.swift.swiftpm` and Xcode `DerivedData` — child expansion works, hash stripping visible, workspace path surfaces in detail panel, safety icons correct (`◐` on DerivedData/repositories, `●` on artifacts/manifests).

## Design spec

`docs/superpowers/specs/2026-04-20-swiftpm-xcode-providers-design.md` (included in the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)