### PR TITLE
Add Go modules + build cache provider (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## [Unreleased]
 
 ### Added
+- **Go provider (#8)**: new `CacheKind::Go` covers the module cache
+  (`$GOMODCACHE`, default `~/go/pkg/mod`) and the build cache
+  (`$GOCACHE`, default `~/Library/Caches/go-build` on macOS,
+  `~/.cache/go-build` on Linux). Full OSV scanning via the `Go`
+  ecosystem and version-check against `proxy.golang.org /@v/list`
+  (filters pseudo-versions and `+incompatible` tags). Module-path
+  bang-escapes (`!uber` → `Uber`) are decoded at `semantic_name` /
+  `package_id` time so OSV sees the real module path. `c` copies a
+  `go get <module>@<version>` upgrade command. Module cache is Safe;
+  build cache is Caution.
+- **`providers::pre_delete` hook**: new dispatch that lets providers
+  prepare a subtree before `remove_dir_all`. Default is a no-op so
+  existing providers are unaffected. The Go provider implements it to
+  `chmod -R +w` the module tree — Go `chmod -w`'s extracted modules
+  by design, and without the hook `remove_dir_all` fails silently.
+  Additional future use-cases: stripping macOS `com.apple.quarantine`
+  xattrs, releasing file handles, pausing watchers.
 - **SwiftPM provider (#11)**: detects `~/Library/Caches/org.swift.swiftpm`
   (macOS) and `~/.cache/org.swift.swiftpm` (Linux). Classifies
   `repositories/` as Caution (re-clone cost on rebuild) and

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Developer machines accumulate tens of gigabytes of invisible cache data — ML m
 ## Why
 
 - **ML models** (HuggingFace, PyTorch, Whisper) — tens of GB you forgot about
-- **Package caches** (pip, uv, npm, Yarn, pnpm, Bun, Cargo, Maven, Gradle, SwiftPM, Homebrew) — old versions with known CVEs
+- **Package caches** (pip, uv, npm, Yarn, pnpm, Bun, Cargo, Maven, Gradle, Go, Homebrew) — old versions with known CVEs
 - **Xcode DerivedData** — often 50–200 GB on macOS dev machines; never cleaned
+- **Swift Package Manager** — reclaim space from cached git clones and artifacts; no CVE scanning yet (OSV `SwiftURL` coverage is sparse)
 - **npm supply chain risk** — transitive deps with install scripts hiding in npx cache
 - **Build artifacts** (pre-commit hooks, Prisma engines) — stale and re-downloadable
 
@@ -78,7 +79,7 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 ### Browse and Understand
 
 - **Two-pane TUI** — navigable tree on the left, details on the right
-- **19 cache providers** — semantic names instead of hash directories
+- **20 cache providers** — semantic names instead of hash directories
 - **Safety levels** — green (safe to delete), yellow (may cause rebuilds), red (contains state)
 - **Sort** by size, name, or last modified
 - **Search** with `/` — case-insensitive filter across the tree
@@ -125,6 +126,7 @@ ccmd --root ~/.cache/huggingface  # scan a specific directory
 | Gradle | `~/.gradle/caches` | `group:artifact version` from `files-2.1` layout |
 | SwiftPM | `~/Library/Caches/org.swift.swiftpm` (macOS), `~/.cache/org.swift.swiftpm` (Linux) | Package names from `repositories/` and `artifacts/` |
 | Xcode | `~/Library/Developer/Xcode/DerivedData`, `~/Library/Developer/Xcode/iOS DeviceSupport`, `~/Library/Developer/CoreSimulator/Caches` | Workspace path from `Info.plist`, iOS version strings |
+| Go | `~/go/pkg/mod` (module cache), `$GOCACHE` / `~/Library/Caches/go-build` (build cache) | Module paths (bang-decoded) with versions from `cache/download/<module>/@v/*.zip` |
 
 ## Provider Capabilities
 
@@ -151,6 +153,7 @@ All providers support tree navigation, size display, and deletion. This matrix s
 | Gradle | Safe; `build-cache-*/` + `transforms-*/` = **Caution** | OSV `Maven` | Maven Central | `implementation '…'` line |
 | SwiftPM | `repositories/` = **Caution** (re-clone); `artifacts/` + `manifests/` = Safe; unknown subdirs = **Caution** | — ¹ | — ¹ | — ¹ |
 | Xcode | `DerivedData/` = **Caution** (5–30 min rebuild); `iOS DeviceSupport/` + `CoreSimulator/Caches/` = Safe | — ² | — ² | — ² |
+| Go | `pkg/mod` = Safe (re-resolvable from proxy); `go-build` = **Caution** (cold rebuild cost) | OSV `Go` | proxy.golang.org `/@v/list` | `go get` |
 
 Legend:
 - **Safe** = re-downloadable, free to delete (shown with `●` in the detail panel).

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 
 - [ ] **Yarn** — `~/.cache/yarn`, Berry PnP cache (`#1`)
 - [ ] **pnpm** — `~/.local/share/pnpm/store` (`#1`)
-- [ ] **Go modules** — `~/go/pkg/mod`, `~/go/pkg/mod/cache`
+- [x] **Go modules** — `~/go/pkg/mod`, `~/go/pkg/mod/cache` (#8)
 - [ ] **Conda / Mamba** — `~/anaconda3/pkgs`, `~/.conda/pkgs`, `~/miniforge3/pkgs`
 - [ ] **Docker** — `~/Library/Containers/com.docker.docker/Data/vms` (macOS), `/var/lib/docker` (Linux), BuildKit cache
 - [ ] **Maven** — `~/.m2/repository`

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -101,6 +101,13 @@ work but silently fail on that axis.
       there's no CLI — note it in the CHANGELOG explicitly).
 - [ ] `safety()` arm if any path inside the cache is not `Safe` by
       default.
+- [ ] `pre_delete()` arm **only if** the cache needs custodial setup
+      before `remove_dir_all` — e.g. Go `chmod -w`'s its extracted
+      module tree so the hook must `chmod -R +w` before delete.
+      Default is a no-op `Ok(())` via the `_` fall-through; don't add
+      an arm unless your provider actually needs one. A returned
+      `Err(String)` aborts the delete and increments the `errored`
+      counter in the status line.
 
 ### Tree & config (`src/tree/node.rs`, `src/config.rs`)
 
@@ -300,6 +307,20 @@ an essay.
   avoids a `plist` crate dependency; Xcode always emits XML for
   DerivedData's `Info.plist`, and char-boundary-safe slicing keeps
   multi-byte workspace paths (日本語) from panicking.
+- **Go (#8):** first provider to need a pre-delete hook — Go
+  `chmod -R -w`'s its extracted module tree
+  (`pkg/mod/<module>@<version>/`), so `remove_dir_all` fails silently
+  without a prep step. The `providers::pre_delete` dispatch was added
+  in this PR; default is `_ => Ok(())` so existing providers stay
+  untouched. If a future cache needs similar prep (xattr strip,
+  watcher pause, file-handle release), that's the seam. Also: Go
+  bang-escapes uppercase ASCII letters on disk (`github.com/Uber/zap`
+  → `github.com/!uber/zap`). Decode at `semantic_name` /
+  `package_id` so OSV sees the real module path; re-encode when
+  building the proxy.golang.org URL. And: Go's pseudo-versions
+  (`v0.0.0-YYYYMMDDHHMMSS-<12hex>`) must be filtered out of the
+  registry's `/@v/list` output — otherwise the outdated signal shows
+  a random recent commit instead of a real tagged release.
 
 <!--
 Template for new entries:

--- a/docs/superpowers/specs/2026-04-21-go-provider-design.md
+++ b/docs/superpowers/specs/2026-04-21-go-provider-design.md
@@ -1,0 +1,336 @@
+# Go modules + build cache Provider Support
+
+**Date:** 2026-04-21
+**Issue:** [#8](https://github.com/juliensimon/cache-commander/issues/8)
+**Status:** Design
+
+## Summary
+
+Add a `Go` cache provider covering both the **module cache** (`$GOMODCACHE`, default `~/go/pkg/mod`) and the **build cache** (`$GOCACHE`, default `~/Library/Caches/go-build` on macOS / `~/.cache/go-build` on Linux). Module cache supports full OSV + version-check + upgrade-command; build cache is disk-hygiene only. Ships alongside a new `providers::pre_delete` dispatch — the Go module cache is `chmod -w`'d by design, so `remove_dir_all` needs a preparatory `chmod -R +w` walk. The hook is a no-op for every other existing provider.
+
+## Approach
+
+One `CacheKind::Go` variant covering both caches, with safety + semantic_name dispatched by path component (same pattern as Gradle's mixed Safe/Caution subtrees).
+
+## Provider: Go (`src/providers/go_mod.rs`)
+
+Module file named `go_mod` because `go.rs` collides with Rust's tendency to attract `go`-prefixed identifier confusion, and Cargo's file-name lowercase convention preserves readability.
+
+### Detection
+
+`detect(path)` returns `CacheKind::Go` when any of these hold:
+- Direct-name match on `go-build` (build cache root).
+- Ancestor walk: any ancestor named `mod` with parent named `pkg` (module cache — matches `$GOPATH/pkg/mod`). Component-based to avoid L1 substring leaks; `has_adjacent_components(path, "pkg", "mod")` is the canonical check.
+
+Negative cases (tests):
+- `pkg-mod-backup/...` → must NOT detect (L1 confusable suffix).
+- `go-build-backup/...` → must NOT detect.
+- A random `mod/` directory not under `pkg/` → Unknown.
+
+### Module-path bang-decoding
+
+Go bang-escapes uppercase letters to `!<lowercase>` on disk (e.g. `Uber` → `!uber`) so that case-insensitive filesystems don't collide `github.com/GoGo/protobuf` with `github.com/gogo/protobuf`. Applied everywhere the module path appears on disk: `cache/download/<module>/@v/...` and extracted `<module>@<version>/`.
+
+A single `decode_module_path(s: &str) -> String` helper decodes `!x` → uppercase `X`. Used by `semantic_name` and `package_id` so OSV + display both see the real module path.
+
+Edge cases (tests):
+- `!u!ber` → `Uber`
+- `github.com/!golang/!mock` → `github.com/Golang/Mock`
+- Trailing lone `!` → pass through unchanged (not a valid escape; we never introduce panics).
+- Non-ASCII chars → pass through (L2 guard).
+
+### Semantic Names
+
+**Module cache:**
+- `.../cache/download/<module>/@v/<version>.zip` → `<decoded-module> <version>`
+  - Module path is the relative path from `download/` up to (but excluding) `@v`, joined with `/`.
+  - Version is the filename with the `.zip` suffix stripped. Go versions look like `v1.2.3`, `v1.2.3-alpha.1`, `v0.0.0-20210101120000-abc123def456` (pseudo-version), or `v2.0.0+incompatible` — all pass through as-is to the display.
+- `.../pkg/mod/<module>@<version>/` extracted dir → same format, derived from the `@`-split of the last path component *and* any parent components that form the module path.
+- `.../cache/download/sumdb/<host>/lookup/<module>@<version>` → `None` (internal checksum data).
+- `.info`, `.mod`, `.ziphash` files → `None` (sibling metadata of the canonical `.zip`).
+
+**Build cache:**
+- All entries under `go-build/` → `None`. Content-addressed hex blobs (`<2hex>/<hash>-<action>`); no human-meaningful name.
+
+**Root directories themselves** (`go-build`, `mod`) → `None`. Tree renders them literally.
+
+### Package Identification
+
+`package_id()` returns `Some(PackageId)` **only** for `.zip` files in `cache/download/.../@v/`. Ecosystem `"Go"`. Name is the decoded module path. Version is the filename stem.
+
+Dedup rationale (L9): `cache/download/<module>/@v/<version>.{info,mod,zip,ziphash}` are four sibling files per package; without restricting to `.zip`, every module would count 4×. Maven's `.jar`-only rule is the direct precedent.
+
+Extracted directories under `pkg/mod/` also get `package_id: None` — we count only the canonical artifact to avoid double-counting the same package under two layouts.
+
+### Metadata
+
+Contextual `Contents:` labels on the known roots:
+- `pkg/mod` → `Module cache (re-downloadable from proxy.golang.org / VCS)`.
+- `go-build` → `Build cache (rebuildable, cold rebuild is minutes on large repos)`.
+- `cache/download/sumdb` → `Module checksum database (authoritative; re-downloadable)`.
+
+No per-file metadata.
+
+### Safety
+
+- `pkg/mod` subtree → `SafetyLevel::Safe` (re-resolvable).
+- `go-build` subtree → `SafetyLevel::Caution` (cold rebuild cost; matches Gradle `build-cache-*` / `transforms-*`).
+- Unknown subdirs under either root → `Caution` (conservative).
+
+Classification uses component-level matching (L1), not substring.
+
+### Upgrade Command
+
+`go get <module>@<version>` via the existing `upgrade_command` dispatch. Module paths contain `/`, which is in the `is_safe_for_shell` allowlist. `@` is also allowed. No new shell sanitization needed.
+
+### Registry / OSV
+
+- OSV ecosystem `Go` — no `registry.rs` arm needed for OSV (dispatched by ecosystem string).
+- Version-check registry: `https://proxy.golang.org/<module-path>/@v/list` returns newline-delimited versions (UTF-8, no JSON). Parser picks the highest non-pseudo semver:
+  - Skip lines matching the pseudo-version regex `v0\.0\.0-\d{14}-[0-9a-f]{12}` (timestamped git-hash format).
+  - Skip lines ending in `+incompatible` when a non-incompatible option exists; fall back to `+incompatible` if that's all there is.
+  - Compare via the existing `compare_versions` helper; L3 lesson says pre-release (`-alpha.1`) must compare correctly.
+
+Module path in the URL uses the **decoded** form (no bang-escapes), per proxy.golang.org spec. But the module path stored in `PackageId.name` is decoded already, so the URL builder just URL-escapes slashes-as-slashes and passes through.
+
+## New architecture: pre-delete hook
+
+Add to `src/providers/mod.rs`:
+
+```rust
+/// Custodial setup before the tree attempts `remove_dir_all` on a cache
+/// subtree. Default is a no-op; providers override when the filesystem
+/// needs preparation (e.g. stripping read-only flags). Errors surface
+/// as the existing `errored` counter in the delete status line.
+pub fn pre_delete(kind: CacheKind, path: &Path) -> Result<(), String> {
+    match kind {
+        CacheKind::Go => go_mod::pre_delete(path),
+        _ => Ok(()),
+    }
+}
+```
+
+`go_mod::pre_delete` walks `path` (if it's under `pkg/mod`) and `chmod -R +w`'s each entry. On the build cache path it's a no-op — Go keeps those writable. Errors from individual `chmod` calls are swallowed; only a catastrophic walk failure returns `Err`.
+
+Call site: `src/app.rs::perform_delete`, immediately before the `remove_dir_all` / `remove_file` branch. If `pre_delete` returns `Err`, increment `errored` and skip the delete for that path.
+
+Why a new trait method (Approach A), not an inline chmod for `CacheKind::Go` in the delete site:
+- The delete site stays provider-agnostic. Adding a `if kind == CacheKind::Go` branch there bakes Go semantics into a generic code path.
+- Future providers that need similar setup (xattr strip, file-handle release, inotify pause) have a clean seam.
+- Cost is minimal: ~15 lines of dispatch + a Go-provider function, all testable in isolation.
+
+## Config (`src/config.rs`)
+
+Add `probe_go_paths()` following the `probe_yarn_paths()` pattern:
+
+```rust
+fn probe_go_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(output) = run_with_timeout("go", &["env", "GOMODCACHE"])
+        && output.status.success()
+    {
+        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = PathBuf::from(&path_str);
+        if path.exists() {
+            paths.push(path);
+        }
+    }
+
+    if let Some(output) = run_with_timeout("go", &["env", "GOCACHE"])
+        && output.status.success()
+    {
+        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let path = PathBuf::from(&path_str);
+        if path.exists() && !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+
+    // Fallback when `go` isn't on PATH: add well-known default locations.
+    let home = dirs_home();
+    let fallback_mod = home.join("go/pkg/mod");
+    if fallback_mod.exists() && !paths.contains(&fallback_mod) {
+        paths.push(fallback_mod);
+    }
+
+    paths
+}
+```
+
+Filter against `is_ancestor_or_descendant(&existing_roots)` before pushing, so `$GOCACHE = ~/.cache/go-build` (Linux default) or `~/Library/Caches/go-build` (macOS default) gets dropped when `~/.cache` / `~/Library/Caches` are already roots. Same fix as SwiftPM — prevents the duplicate-TreeNode bug.
+
+`default_for_test()` remains empty. A config test asserts the Go module cache root appears when `~/go/pkg/mod` exists; skips cleanly otherwise (L6 / L9 patterns).
+
+## Dispatch Integration (`src/providers/mod.rs`)
+
+Add `pub mod go_mod;`. Add `CacheKind::Go` arms to:
+- `detect()` — direct-name on `go-build`, adjacent-components on `pkg/mod`.
+- `semantic_name()` → `go_mod::semantic_name`.
+- `metadata()` → `go_mod::metadata`.
+- `package_id()` → `go_mod::package_id`.
+- `upgrade_command()` — `Some(format!("go get {name}@{version}"))`.
+- `safety()` — Safe for `pkg/mod`, Caution for `go-build`, component-based.
+- `pre_delete()` — new dispatch (see above).
+
+## CacheKind Enum (`src/tree/node.rs`)
+
+Add `Go` variant with:
+- `label()` → `"Go"`
+- `description()` → `"Go module cache and build cache"`
+- `url()` → `"https://go.dev"`
+
+Placed alphabetically between `Gradle` and `SwiftPm`.
+
+## Registry (`src/security/registry.rs`)
+
+Add:
+
+```rust
+pub fn parse_go_proxy_list(body: &str) -> Option<String> {
+    body.lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .filter(|l| !is_pseudo_version(l))
+        .filter(|l| !l.ends_with("+incompatible"))
+        .max_by(|a, b| compare_versions(a, b))
+        .or_else(|| {
+            // All versions are pseudo or +incompatible — fall back to max.
+            body.lines()
+                .map(|l| l.trim())
+                .filter(|l| !l.is_empty())
+                .max_by(|a, b| compare_versions(a, b))
+        })
+        .map(|s| s.to_string())
+}
+
+fn is_pseudo_version(v: &str) -> bool {
+    // vX.Y.Z-YYYYMMDDHHMMSS-<12hex>  (Go pseudo-version format)
+    // Cheap check: split on '-', look for a 14-digit timestamp chunk
+    // followed by a 12-hex-digit chunk.
+    let parts: Vec<&str> = v.split('-').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    let ts = parts[parts.len() - 2];
+    let hash = parts[parts.len() - 1];
+    ts.len() == 14
+        && ts.chars().all(|c| c.is_ascii_digit())
+        && hash.len() == 12
+        && hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+```
+
+Update `build_registry_url` to emit `https://proxy.golang.org/<url-escaped-module>/@v/list` for `"Go"`. Update `parse_registry_response` to dispatch to `parse_go_proxy_list`.
+
+## UI Impact
+
+None. Existing tree/detail-panel/delete flow is provider-agnostic once `pre_delete` is wired; the Go variant gets detail-panel labels, safety icons, and upgrade-command copy for free.
+
+## Testing Strategy
+
+### Tier 1: Unit Tests (in-module)
+
+All strict TDD (RED → GREEN → refactor).
+
+**Detection:**
+- `detect_go_build_root`, `detect_go_mod_cache_deep_path`, `detect_go_rejects_pkg_mod_backup` (L1), `detect_go_rejects_go_build_backup` (L1), `detect_go_rejects_unrelated_mod_dir`.
+
+**Bang-decoding:**
+- `decode_module_path_single_uppercase` (`!u!ber` → `Uber`).
+- `decode_module_path_in_real_module_path` (`github.com/!golang/!mock` → `github.com/Golang/Mock`).
+- `decode_module_path_trailing_lone_bang_passes_through`.
+- `decode_module_path_non_ascii_passes_through` (L2).
+
+**Semantic names:**
+- `semantic_name_zip_file` → `"<module> <version>"`.
+- `semantic_name_extracted_dir` → same format.
+- `semantic_name_sumdb_file_returns_none`.
+- `semantic_name_info_mod_ziphash_return_none`.
+- `semantic_name_build_cache_entry_returns_none`.
+- `semantic_name_bang_decoded_module`.
+
+**Package identity:**
+- `package_id_from_zip`.
+- `package_id_from_info_returns_none` (dedup guard, L9).
+- `package_id_from_mod_returns_none`.
+- `package_id_from_ziphash_returns_none`.
+- `package_id_from_extracted_dir_returns_none` (dedup — counted via `.zip`).
+- `package_id_module_path_is_decoded`.
+
+**Safety:**
+- `safety_pkg_mod_is_safe`.
+- `safety_go_build_is_caution`.
+- `safety_unknown_subdir_is_caution`.
+- `safety_rejects_confusable_suffix` (L1).
+
+**Metadata:**
+- Three `metadata_<root>_reports_contents` tests.
+- `metadata_leaf_file_returns_empty`.
+
+**Registry parser:**
+- `parse_go_proxy_list_picks_highest_semver`.
+- `parse_go_proxy_list_skips_pseudo_versions`.
+- `parse_go_proxy_list_prefers_non_incompatible`.
+- `parse_go_proxy_list_handles_pre_release`.
+- `parse_go_proxy_list_empty_body_returns_none`.
+
+**Pre-delete:**
+- `pre_delete_chmods_read_only_module_cache` — create a fake mod cache with `chmod -w` files, call `pre_delete`, assert files are writable afterwards.
+- `pre_delete_on_build_cache_path_is_noop`.
+- `pre_delete_default_dispatch_is_ok_for_all_other_kinds` — loop through every `CacheKind` and assert `pre_delete` returns `Ok(())`.
+- `perform_delete_calls_pre_delete_before_remove` — integration test in `src/app.rs` tests, using a synthetic read-only fixture.
+
+### Tier 2: Integration Tests (`tests/integration_go.rs`)
+
+Synthetic fixtures:
+- Build a tempdir shaped like `$GOMODCACHE`: `cache/download/github.com/!uber/zap/@v/v1.27.0.zip`, sibling `.info` / `.mod`.
+- Verify full pipeline: detect → semantic_name (`github.com/Uber/zap 1.27.0`) → safety (Safe) → package_id dedup (exactly one per unique module).
+- Build cache fixture with synthetic `go-build/ab/abcdef-link` — verify detect=Go, semantic_name=None, safety=Caution.
+
+### Tier 3: E2E Tests (`tests/e2e_go_provider.rs`, feature-gated `e2e`)
+
+Per `feedback_e2e_full_pipeline`:
+1. Install `go` if not on PATH (skip cleanly on Windows-style hosts with a clear message).
+2. Create tempdir. Set `GOMODCACHE=<tmp>/mod`, `GOCACHE=<tmp>/build`, `GOPATH=<tmp>/gopath`.
+3. Run `go get github.com/gin-gonic/gin@v1.6.0` — known outdated (latest is 1.10+) and has at least one OSV-tracked CVE (CVE-2023-26125, CVE-2023-29401 etc.).
+4. Verify scanner pipeline:
+   - `discover_packages` finds `github.com/gin-gonic/gin` with version `v1.6.0`.
+   - `scan_vulns` returns at least one vuln.
+   - `check_latest` against proxy.golang.org returns a version strictly greater than `v1.6.0`.
+5. **Delete-flow verification**: invoke `perform_delete` on the module cache path. Assert deletion succeeds end-to-end (the pre-delete hook unblocks `remove_dir_all`). Without the hook, this step fails — canary for the main motivator.
+6. Teardown: tempdir drops (auto-cleaned on green per `feedback_e2e_automated_and_cleaned_up`).
+
+## Docs Updates
+
+- `README.md` — add a row to Supported Caches (19 → 20 providers), add a row to the Provider Capabilities matrix, bump the Features count.
+- `CHANGELOG.md` — `[Unreleased]` Added bullet covering both module + build caches, noting the new `pre_delete` hook.
+- `docs/user-guide.md` — list Go under the vuln / outdated / upgrade-cmd participating providers.
+- `docs/adding-a-provider.md` — **document the new pre-delete hook** in §2's wire-up checklist. Add a Lessons Learned line.
+- `TODO.md` — tick issue #8.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/tree/node.rs` | Add `Go` variant |
+| `src/providers/mod.rs` | Add `pub mod go_mod;`, dispatch arms, new `pre_delete` dispatch |
+| `src/providers/go_mod.rs` | **New** — provider |
+| `src/config.rs` | `probe_go_paths()`, subsumed-by-parent-root filter |
+| `src/security/registry.rs` | `parse_go_proxy_list`, `is_pseudo_version`, `Go` URL arm |
+| `src/app.rs` | Call `providers::pre_delete` in `perform_delete` |
+| `tests/integration_go.rs` | **New** — Tier 2 pipeline |
+| `tests/e2e_go_provider.rs` | **New** — Tier 3 real-tool |
+| `README.md`, `CHANGELOG.md`, `docs/user-guide.md`, `docs/adding-a-provider.md`, `TODO.md` | docs |
+
+## Out of Scope
+
+- **Nested vendored module caches** (`<repo>/vendor/`). Different layout, not a user-wide cache.
+- **Go workspace cache** (`go.work` / `go.work.sum`). Project-local.
+- **Garbage collection of stale modules** per Go 1.22+'s `GOMODCACHE` hygiene. Different feature — user wants to understand what's there and delete selectively, not auto-GC.
+
+## Risks
+
+- **Proxy endpoint availability**: `proxy.golang.org` occasionally rate-limits. The existing 10s `ureq` timeout + partial-failure reporting (L7) handles this; no new work needed.
+- **Bang-decoding edge case**: a pathological module path with lone `!` could theoretically confuse decoder. Tests cover trailing-bang pass-through to make the behavior explicit.
+- **Pre-delete hook blast radius**: a bug in the default `Ok(())` dispatch could accidentally block deletes for unrelated providers. Mitigated by the mandatory `pre_delete_default_dispatch_is_ok_for_all_other_kinds` regression test.

--- a/docs/superpowers/specs/2026-04-21-go-provider-design.md
+++ b/docs/superpowers/specs/2026-04-21-go-provider-design.md
@@ -87,11 +87,11 @@ Classification uses component-level matching (L1), not substring.
 
 - OSV ecosystem `Go` — no `registry.rs` arm needed for OSV (dispatched by ecosystem string).
 - Version-check registry: `https://proxy.golang.org/<module-path>/@v/list` returns newline-delimited versions (UTF-8, no JSON). Parser picks the highest non-pseudo semver:
-  - Skip lines matching the pseudo-version regex `v0\.0\.0-\d{14}-[0-9a-f]{12}` (timestamped git-hash format).
+  - Skip lines that look like pseudo-versions. Per Go's three pseudo-version forms, the rule is: the second-to-last `-` segment's last dot-piece is 14 digits AND the last `-` segment is 12 hex chars. This covers `v0.0.0-YYYYMMDDHHMMSS-<12hex>`, `vX.Y.Z-pre.0.YYYYMMDDHHMMSS-<12hex>`, and `vX.Y.(Z+1)-0.YYYYMMDDHHMMSS-<12hex>`.
   - Skip lines ending in `+incompatible` when a non-incompatible option exists; fall back to `+incompatible` if that's all there is.
   - Compare via the existing `compare_versions` helper; L3 lesson says pre-release (`-alpha.1`) must compare correctly.
 
-Module path in the URL uses the **decoded** form (no bang-escapes), per proxy.golang.org spec. But the module path stored in `PackageId.name` is decoded already, so the URL builder just URL-escapes slashes-as-slashes and passes through.
+Module path in the URL uses the Go module proxy's **escaped** form — uppercase ASCII → `!<lower>` per the proxy protocol. `PackageId.name` stores the decoded form for display and OSV parity, so the URL builder re-applies the bang-escape via `encode_go_module_path`. (Go's module-path charset excludes `!`, so no `!!` round-trip is needed: `golang.org/x/mod/module.CheckPath` rejects `!` in decoded paths, and `UnescapePath` rejects `!!` as malformed — confirmed empirically against the upstream library.)
 
 ## New architecture: pre-delete hook
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -135,6 +135,7 @@ Participating providers (cover all package-manager ecosystems supported by OSV):
 - **npm**, **Yarn**, **pnpm**, **Bun** → OSV `npm`
 - **Cargo** → OSV `crates.io`
 - **Maven**, **Gradle** → OSV `Maven`
+- **Go** → OSV `Go`
 
 Other providers (HuggingFace, Homebrew, Whisper, GitHub CLI, PyTorch, Chroma, Prisma, pre-commit, SwiftPM, Xcode) are disk-hygiene only — pressing `v`/`V` on entries from those providers is a no-op. See the [Provider Capabilities matrix](../README.md#provider-capabilities) in the README for the full list.
 
@@ -155,6 +156,7 @@ Registries queried:
 - **npm**, **Yarn**, **pnpm**, **Bun** → npm registry
 - **Cargo** → crates.io
 - **Maven**, **Gradle** → Maven Central (`maven-metadata.xml`, prefers `<release>` over `<latest>` to avoid SNAPSHOTs)
+- **Go** → proxy.golang.org `/@v/list` (skips pseudo-versions and `+incompatible` tags)
 
 Providers without a public registry (SwiftPM, Xcode, etc.) skip this step. See the README's Provider Capabilities matrix for the full list.
 
@@ -267,6 +269,7 @@ Shell commands:
 - **pnpm** → `pnpm add express@4.19.0`
 - **Bun** → `bun add express@4.19.0`
 - **Cargo** → `cargo update -p serde`
+- **Go** → `go get github.com/gin-gonic/gin@v1.10.0`
 
 Paste-ready snippets (JVM ecosystems have no single-line CLI upgrade):
 - **Maven** → `<dependency><groupId>…</groupId><artifactId>…</artifactId><version>…</version></dependency>`

--- a/src/app.rs
+++ b/src/app.rs
@@ -554,6 +554,16 @@ impl App {
 
             // Measure size before deleting
             let size = crate::scanner::walker::dir_size(path);
+
+            // Provider-specific pre-delete hook (e.g. chmod +w on Go's
+            // read-only module cache). Default is a no-op. Hook errors
+            // count as failures — the subsequent remove_dir_all would
+            // just hit the same problem.
+            if crate::providers::pre_delete(kind, path).is_err() {
+                errored += 1;
+                continue;
+            }
+
             let outcome = if path.is_dir() {
                 std::fs::remove_dir_all(path)
             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -973,29 +973,37 @@ mod tests {
         }
     }
 
+    /// Process-wide lock for tests that mutate environment variables.
+    /// Rust 2024 makes `set_var` unsafe specifically because tests
+    /// run in parallel by default and env-var mutations race with
+    /// other threads reading them. Tests that touch env vars should
+    /// take this lock first.
+    fn env_var_test_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
     #[test]
     fn probe_go_paths_respects_gomodcache_env_var() {
         // Set GOMODCACHE to a fixture directory and ensure probing
         // picks it up. This is the canonical RED→GREEN for the probe
-        // because it exercises the `go env GOMODCACHE` branch.
-        let tmp = std::env::temp_dir().join(format!("ccmd-go-mod-test-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
-        // SAFETY: tests are serial within a single process for this env var usage.
+        // because it exercises the env branch without needing `go` on
+        // PATH. Unlike the previous version, we no longer short-circuit
+        // on an empty result — the env-var branch runs whether or not
+        // `go` is installed, so an empty paths vector here IS a failure.
+        let _guard = env_var_test_lock().lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: held across both set/remove under env_var_test_lock.
         unsafe {
-            std::env::set_var("GOMODCACHE", &tmp);
+            std::env::set_var("GOMODCACHE", tmp.path());
         }
         let paths = probe_go_paths();
         unsafe {
             std::env::remove_var("GOMODCACHE");
         }
-        let _ = std::fs::remove_dir_all(&tmp);
 
-        // On hosts without `go` on PATH the probe returns empty; skip.
-        if paths.is_empty() {
-            return;
-        }
         assert!(
-            paths.iter().any(|p| p == &tmp),
+            paths.iter().any(|p| p == tmp.path()),
             "expected GOMODCACHE path in probe output, got {paths:?}"
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,16 @@ impl Default for Config {
             }
         }
 
+        // Go cache paths. Only add a path if it isn't already subsumed
+        // by an existing root — default $GOCACHE lives under
+        // ~/Library/Caches (macOS) or ~/.cache (Linux), so probing
+        // naively would duplicate TreeNodes (the SwiftPM bug).
+        for path in probe_go_paths() {
+            if !roots.contains(&path) && !is_ancestor_or_descendant(&path, &roots) {
+                roots.push(path);
+            }
+        }
+
         Self {
             roots,
             sort_by: SortField::Size,
@@ -442,6 +452,49 @@ fn probe_bun_paths() -> Vec<PathBuf> {
     let default_cache = home.join(".bun/install/cache");
     if default_cache.exists() && !paths.contains(&default_cache) {
         paths.push(default_cache);
+    }
+
+    paths
+}
+
+fn probe_go_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Prefer an explicit GOMODCACHE env override — lets tests and users
+    // redirect the probe without needing a real `go` on PATH.
+    if let Ok(gomc) = std::env::var("GOMODCACHE") {
+        let path = PathBuf::from(&gomc);
+        if path.exists() {
+            paths.push(path);
+        }
+    } else if let Some(output) = run_with_timeout("go", &["env", "GOMODCACHE"])
+        && output.status.success()
+    {
+        let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path_str.is_empty() {
+            let path = PathBuf::from(&path_str);
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+    }
+
+    // Fallback: ~/go/pkg/mod (the default location when GOPATH is unset).
+    let fallback = dirs_home().join("go/pkg/mod");
+    if fallback.exists() && !paths.contains(&fallback) {
+        paths.push(fallback);
+    }
+
+    // The build cache ($GOCACHE) defaults to ~/Library/Caches/go-build on
+    // macOS and ~/.cache/go-build on Linux — both subsumed by existing
+    // roots, so we intentionally do NOT probe for it here. If a user
+    // sets $GOCACHE to a non-default location outside those parents, the
+    // caller filters via is_ancestor_or_descendant before pushing.
+    if let Ok(gocache) = std::env::var("GOCACHE") {
+        let path = PathBuf::from(&gocache);
+        if path.exists() && !paths.contains(&path) {
+            paths.push(path);
+        }
     }
 
     paths
@@ -904,6 +957,81 @@ mod tests {
         assert!(
             config.roots.iter().any(|r| r == &sim),
             "expected CoreSimulator/Caches root, got {:?}",
+            config.roots
+        );
+    }
+
+    // --- Go probing ---
+
+    #[test]
+    fn probe_go_paths_returns_absolute_paths() {
+        // Same invariant as the yarn/pnpm probes: every returned path
+        // must be absolute, whether `go` is installed or not.
+        let paths = probe_go_paths();
+        for p in &paths {
+            assert!(p.is_absolute(), "probe_go_paths returned relative: {p:?}");
+        }
+    }
+
+    #[test]
+    fn probe_go_paths_respects_gomodcache_env_var() {
+        // Set GOMODCACHE to a fixture directory and ensure probing
+        // picks it up. This is the canonical RED→GREEN for the probe
+        // because it exercises the `go env GOMODCACHE` branch.
+        let tmp = std::env::temp_dir().join(format!("ccmd-go-mod-test-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        // SAFETY: tests are serial within a single process for this env var usage.
+        unsafe {
+            std::env::set_var("GOMODCACHE", &tmp);
+        }
+        let paths = probe_go_paths();
+        unsafe {
+            std::env::remove_var("GOMODCACHE");
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // On hosts without `go` on PATH the probe returns empty; skip.
+        if paths.is_empty() {
+            return;
+        }
+        assert!(
+            paths.iter().any(|p| p == &tmp),
+            "expected GOMODCACHE path in probe output, got {paths:?}"
+        );
+    }
+
+    #[test]
+    fn default_config_includes_go_module_cache_when_exists() {
+        let go_mod = dirs_home().join("go/pkg/mod");
+        if !go_mod.exists() {
+            return; // host without Go — skip cleanly
+        }
+        let config = Config::default();
+        assert!(
+            config.roots.iter().any(|r| r == &go_mod),
+            "expected go/pkg/mod root in config, got {:?}",
+            config.roots
+        );
+    }
+
+    #[test]
+    fn default_config_does_not_duplicate_go_build_under_existing_root() {
+        // Default GOCACHE on macOS is ~/Library/Caches/go-build (under
+        // the Library/Caches root); on Linux it's ~/.cache/go-build
+        // (under ~/.cache). Either way the build cache is subsumed by
+        // an existing root — adding it as its own root would duplicate
+        // TreeNodes, same bug as SwiftPM had before we fixed it.
+        let macos_gocache = dirs_home().join("Library/Caches/go-build");
+        let linux_gocache = dirs_home().join(".cache/go-build");
+        let config = Config::default();
+        assert!(
+            !config.roots.iter().any(|r| r == &macos_gocache),
+            "GOCACHE must not duplicate ~/Library/Caches root, got {:?}",
+            config.roots
+        );
+        assert!(
+            !config.roots.iter().any(|r| r == &linux_gocache),
+            "GOCACHE must not duplicate ~/.cache root, got {:?}",
             config.roots
         );
     }

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -1,0 +1,28 @@
+// Go module cache + build cache provider.
+//
+// Two logical caches under one CacheKind::Go:
+// - Module cache (`$GOMODCACHE`, default `~/go/pkg/mod`): Safe.
+//   Tarballs at `cache/download/<module>/@v/<version>.zip` plus extracted
+//   copies at `pkg/mod/<module>@<version>/`. Go chmod -w's the extracted
+//   tree, which is why this provider ships a pre_delete hook.
+// - Build cache (`$GOCACHE`, default `~/Library/Caches/go-build` on
+//   macOS, `~/.cache/go-build` on Linux): Caution (cold rebuild cost).
+
+use super::MetadataField;
+use std::path::Path;
+
+pub fn semantic_name(_path: &Path) -> Option<String> {
+    None
+}
+
+pub fn metadata(_path: &Path) -> Vec<MetadataField> {
+    Vec::new()
+}
+
+pub fn package_id(_path: &Path) -> Option<super::PackageId> {
+    None
+}
+
+pub fn pre_delete(_path: &Path) -> Result<(), String> {
+    Ok(())
+}

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -114,8 +114,41 @@ fn parse_extracted_module_dir(path: &Path) -> Option<(String, String)> {
     Some((components.join("/"), version.to_string()))
 }
 
-pub fn metadata(_path: &Path) -> Vec<MetadataField> {
-    Vec::new()
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let parent_name = path
+        .parent()
+        .and_then(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    match name.as_str() {
+        "mod" if parent_name == "pkg" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Module cache (re-downloadable from proxy.golang.org / VCS)".into(),
+            });
+        }
+        "go-build" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Build cache (rebuildable, cold rebuild is minutes on large repos)".into(),
+            });
+        }
+        "sumdb" if parent_name == "download" => {
+            fields.push(MetadataField {
+                label: "Contents".into(),
+                value: "Module checksum database (authoritative; re-downloadable)".into(),
+            });
+        }
+        _ => {}
+    }
+
+    fields
 }
 
 pub fn package_id(path: &Path) -> Option<super::PackageId> {
@@ -366,5 +399,51 @@ mod tests {
             "/Users/j/go/pkg/mod/cache/download/sumdb/sum.golang.org/lookup/github.com/foo/bar@v1.0.0",
         );
         assert_eq!(package_id(&path), None);
+    }
+
+    // --- metadata ---
+
+    #[test]
+    fn metadata_pkg_mod_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/go/pkg/mod");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Module cache")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_go_build_root_reports_contents() {
+        let path = PathBuf::from("/Users/j/Library/Caches/go-build");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("Build cache")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_sumdb_reports_contents() {
+        let path = PathBuf::from("/Users/j/go/pkg/mod/cache/download/sumdb");
+        let fields = metadata(&path);
+        assert!(
+            fields
+                .iter()
+                .any(|f| f.label == "Contents" && f.value.contains("checksum")),
+            "got {fields:?}"
+        );
+    }
+
+    #[test]
+    fn metadata_leaf_file_returns_empty() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.zip",
+        );
+        assert!(metadata(&path).is_empty());
     }
 }

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -511,12 +511,13 @@ mod tests {
         // Simulate Go's chmod -R -w on the module tree.
         fs::set_permissions(&file, fs::Permissions::from_mode(0o444)).unwrap();
         fs::set_permissions(&module_dir, fs::Permissions::from_mode(0o555)).unwrap();
+        // Sanity: the file is now non-writable. If a subsequent
+        // fs::write succeeds we've lost the chmod and the test isn't
+        // exercising what we think it is.
         assert!(
-            !file.metadata().unwrap().permissions().readonly() == false,
+            fs::write(&file, "still writable?").is_err(),
             "sanity: file should be read-only before pre_delete runs"
         );
-        // (Write flag is off on the file.)
-        assert!(fs::write(&file, "still writable?").is_err());
 
         // Run the hook.
         assert!(pre_delete(&module_dir).is_ok());

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -11,8 +11,107 @@
 use super::MetadataField;
 use std::path::Path;
 
-pub fn semantic_name(_path: &Path) -> Option<String> {
+pub fn semantic_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    // Build cache entries are opaque content-addressed hex blobs; no
+    // meaningful semantic name.
+    if path_has_component(path, "go-build") {
+        return None;
+    }
+
+    // sumdb entries under cache/download/ are internal checksum data;
+    // the user has no use for per-file names there.
+    if path_has_component(path, "sumdb") {
+        return None;
+    }
+
+    // Known cache-root names render literally.
+    if matches!(name.as_str(), "mod" | "go-build") {
+        return None;
+    }
+
+    // Module zip in the canonical download layout:
+    // .../cache/download/<module>/@v/<version>.zip
+    if let Some((module, version)) = parse_download_zip(path) {
+        return Some(format!("{module} {version}"));
+    }
+
+    // Extracted module directory: .../pkg/mod/<module>@<version>
+    if let Some((module, version)) = parse_extracted_module_dir(path) {
+        return Some(format!("{module} {version}"));
+    }
+
     None
+}
+
+fn path_has_component(path: &Path, target: &str) -> bool {
+    path.components().any(|c| c.as_os_str() == target)
+}
+
+/// Parse `.../cache/download/<module-path>/@v/<version>.zip` into
+/// `(decoded-module, version)`. The module path is the chain of
+/// components between `download/` and `@v/`, joined by `/`.
+fn parse_download_zip(path: &Path) -> Option<(String, String)> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+    let version = name.strip_suffix(".zip")?.to_string();
+
+    // Immediate parent must be `@v`.
+    let mut ancestors = path.ancestors();
+    ancestors.next(); // skip the file itself
+    let at_v = ancestors.next()?;
+    if at_v.file_name()?.to_string_lossy() != "@v" {
+        return None;
+    }
+
+    // Walk up from `@v`'s parent to the `download` marker, collecting
+    // module-path components.
+    let mut components: Vec<String> = Vec::new();
+    let mut current = at_v.parent()?;
+    loop {
+        let comp = current.file_name()?.to_string_lossy().to_string();
+        if comp == "download" {
+            break;
+        }
+        components.push(decode_module_path(&comp));
+        current = current.parent()?;
+    }
+    if components.is_empty() {
+        return None;
+    }
+    components.reverse();
+    Some((components.join("/"), version))
+}
+
+/// Parse `.../pkg/mod/<module-path>@<version>` (extracted source dir)
+/// into `(decoded-module, version)`. Last component carries `@`; the
+/// module path may span multiple parent components above `pkg/mod`.
+fn parse_extracted_module_dir(path: &Path) -> Option<(String, String)> {
+    let name = path.file_name()?.to_string_lossy().to_string();
+    let (last_module_part, version) = name.split_once('@')?;
+    if version.is_empty() {
+        return None;
+    }
+
+    // Parent chain up to `mod` (under `pkg`) carries the rest of the
+    // module path.
+    let mut components: Vec<String> = vec![decode_module_path(last_module_part)];
+    let mut current = path.parent()?;
+    loop {
+        let comp_name = current.file_name()?.to_string_lossy().to_string();
+        if comp_name == "mod" {
+            let grandparent = current.parent()?;
+            if grandparent.file_name()?.to_string_lossy() == "pkg" {
+                break;
+            } else {
+                return None; // `mod/` not under `pkg/` — not the Go layout.
+            }
+        }
+        components.push(decode_module_path(&comp_name));
+        current = current.parent()?;
+    }
+    components.reverse();
+    Some((components.join("/"), version.to_string()))
 }
 
 pub fn metadata(_path: &Path) -> Vec<MetadataField> {
@@ -25,4 +124,161 @@ pub fn package_id(_path: &Path) -> Option<super::PackageId> {
 
 pub fn pre_delete(_path: &Path) -> Result<(), String> {
     Ok(())
+}
+
+/// Decode Go's on-disk bang-escape scheme for module paths.
+/// `!<lowercase>` → uppercase, so `github.com/!uber/zap` → `github.com/Uber/zap`.
+/// Any `!` not followed by a lowercase ASCII letter passes through unchanged.
+fn decode_module_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '!' {
+            match chars.peek() {
+                Some(&next) if next.is_ascii_lowercase() => {
+                    out.push(next.to_ascii_uppercase());
+                    chars.next();
+                }
+                _ => out.push('!'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_module_path_single_uppercase() {
+        // Go only bang-escapes uppercase letters, one `!` per uppercase.
+        // `Uber` → on-disk `!uber`; `UBer` → `!u!ber`.
+        assert_eq!(decode_module_path("!uber"), "Uber");
+        assert_eq!(decode_module_path("!u!ber"), "UBer");
+    }
+
+    #[test]
+    fn decode_module_path_in_real_module_path() {
+        assert_eq!(
+            decode_module_path("github.com/!golang/!mock"),
+            "github.com/Golang/Mock"
+        );
+    }
+
+    #[test]
+    fn decode_module_path_trailing_lone_bang_passes_through() {
+        // Not a valid escape; preserve the trailing `!` rather than
+        // panicking.
+        assert_eq!(decode_module_path("github.com/foo!"), "github.com/foo!");
+    }
+
+    #[test]
+    fn decode_module_path_non_ascii_passes_through() {
+        // L2: multi-byte chars must not panic. Bang-escape only applies
+        // to uppercase ASCII; other codepoints pass through untouched.
+        assert_eq!(decode_module_path("github.com/café"), "github.com/café");
+    }
+
+    #[test]
+    fn decode_module_path_bang_followed_by_non_letter_passes_through() {
+        // `!-` isn't a valid bang-escape; preserve literally.
+        assert_eq!(decode_module_path("foo!-bar"), "foo!-bar");
+    }
+
+    #[test]
+    fn decode_module_path_empty_string() {
+        assert_eq!(decode_module_path(""), "");
+    }
+
+    use std::path::PathBuf;
+
+    // --- semantic_name ---
+
+    #[test]
+    fn semantic_name_module_zip() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.zip",
+        );
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/stretchr/testify v1.8.4".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_module_zip_decodes_bang_escape() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/!uber-go/zap/@v/v1.27.0.zip",
+        );
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/Uber-go/zap v1.27.0".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_extracted_module_dir() {
+        let path = PathBuf::from("/Users/j/go/pkg/mod/github.com/stretchr/testify@v1.8.4");
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/stretchr/testify v1.8.4".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_extracted_module_dir_decodes_bang_escape() {
+        let path = PathBuf::from("/Users/j/go/pkg/mod/github.com/!uber-go/zap@v1.27.0");
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/Uber-go/zap v1.27.0".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_info_file_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.info",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_mod_file_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.mod",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_ziphash_file_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.ziphash",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_sumdb_file_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/sumdb/sum.golang.org/lookup/github.com/foo/bar@v1.0.0",
+        );
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_build_cache_entry_returns_none() {
+        let path = PathBuf::from("/Users/j/Library/Caches/go-build/ab/abcdef123456-d");
+        assert_eq!(semantic_name(&path), None);
+    }
+
+    #[test]
+    fn semantic_name_known_roots_return_none() {
+        for p in ["/Users/j/go/pkg/mod", "/Users/j/Library/Caches/go-build"] {
+            assert_eq!(semantic_name(&PathBuf::from(p)), None, "{p}");
+        }
+    }
 }

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -14,15 +14,31 @@ use std::path::Path;
 pub fn semantic_name(path: &Path) -> Option<String> {
     let name = path.file_name()?.to_string_lossy().to_string();
 
-    // Build cache entries are opaque content-addressed hex blobs; no
-    // meaningful semantic name.
-    if path_has_component(path, "go-build") {
+    // Module zip in the canonical download layout takes priority:
+    // .../cache/download/<module>/@v/<version>.zip. Checking this
+    // FIRST ensures a module whose import path is literally `go-build`
+    // or `sumdb` (both legal Go module-path segments) isn't
+    // mis-classified as a build-cache/sumdb internal entry below.
+    if let Some((module, version)) = parse_download_zip(path) {
+        return Some(format!("{module} {version}"));
+    }
+
+    // sumdb internal checksum data — matched only on the actual
+    // `cache/download/sumdb/` adjacency. Must be checked BEFORE
+    // parse_extracted_module_dir, because a sumdb lookup filename like
+    // `.../lookup/github.com/foo/bar@v1.0.0` ends in `@vX.Y.Z` and
+    // would otherwise be mis-parsed as an extracted module dir.
+    if is_under_cache_sumdb(path) {
         return None;
     }
 
-    // sumdb entries under cache/download/ are internal checksum data;
-    // the user has no use for per-file names there.
-    if path_has_component(path, "sumdb") {
+    // Extracted module directory: .../pkg/mod/<module>@<version>
+    if let Some((module, version)) = parse_extracted_module_dir(path) {
+        return Some(format!("{module} {version}"));
+    }
+
+    // Build cache entries are opaque content-addressed hex blobs.
+    if is_under_build_cache(path) {
         return None;
     }
 
@@ -31,27 +47,36 @@ pub fn semantic_name(path: &Path) -> Option<String> {
         return None;
     }
 
-    // Module zip in the canonical download layout:
-    // .../cache/download/<module>/@v/<version>.zip
-    if let Some((module, version)) = parse_download_zip(path) {
-        return Some(format!("{module} {version}"));
-    }
-
-    // Extracted module directory: .../pkg/mod/<module>@<version>
-    if let Some((module, version)) = parse_extracted_module_dir(path) {
-        return Some(format!("{module} {version}"));
-    }
-
     None
 }
 
-fn path_has_component(path: &Path, target: &str) -> bool {
-    path.components().any(|c| c.as_os_str() == target)
+/// True iff `path` is somewhere under a Go build-cache root (i.e. the
+/// `go-build` component sits adjacent to a well-known GOCACHE parent).
+/// We do NOT treat any `go-build` anywhere in the path as build-cache,
+/// because `go-build` is a legal Go module-path segment on its own.
+fn is_under_build_cache(path: &Path) -> bool {
+    // Known GOCACHE parents: `Caches` (macOS, under `~/Library/Caches`)
+    // or `.cache` (Linux XDG). The check is "adjacent components
+    // <parent> / go-build", which matches the canonical default
+    // locations and a reasonable set of user-set $GOCACHE overrides
+    // under other cache directories.
+    super::has_adjacent_components(path, "Caches", "go-build")
+        || super::has_adjacent_components(path, ".cache", "go-build")
+}
+
+/// True iff `path` points into the `cache/download/sumdb/` checksum-db
+/// subtree (whose layout has `download` immediately above `sumdb`).
+fn is_under_cache_sumdb(path: &Path) -> bool {
+    super::has_adjacent_components(path, "download", "sumdb")
 }
 
 /// Parse `.../cache/download/<module-path>/@v/<version>.zip` into
 /// `(decoded-module, version)`. The module path is the chain of
-/// components between `download/` and `@v/`, joined by `/`.
+/// components between the canonical `cache/download` pair and `@v/`,
+/// joined by `/`. We anchor on the `cache/download` pair (not on any
+/// component named `download`) because `download` is a legal Go
+/// module-path element — e.g. `github.com/foo/download` must not trip
+/// the loop early.
 fn parse_download_zip(path: &Path) -> Option<(String, String)> {
     let name = path.file_name()?.to_string_lossy().to_string();
     let version = name.strip_suffix(".zip")?.to_string();
@@ -64,13 +89,18 @@ fn parse_download_zip(path: &Path) -> Option<(String, String)> {
         return None;
     }
 
-    // Walk up from `@v`'s parent to the `download` marker, collecting
-    // module-path components.
+    // Walk up from `@v`'s parent, collecting module-path components
+    // until we reach a `download` whose parent is `cache`.
     let mut components: Vec<String> = Vec::new();
     let mut current = at_v.parent()?;
     loop {
         let comp = current.file_name()?.to_string_lossy().to_string();
-        if comp == "download" {
+        if comp == "download"
+            && current
+                .parent()
+                .and_then(|p| p.file_name())
+                .is_some_and(|n| n == "cache")
+        {
             break;
         }
         components.push(decode_module_path(&comp));
@@ -159,8 +189,11 @@ pub fn package_id(path: &Path) -> Option<super::PackageId> {
     if !name.ends_with(".zip") {
         return None;
     }
-    // sumdb entries live under cache/download/ but aren't packages.
-    if path_has_component(path, "sumdb") {
+    // sumdb `.zip` entries (if any ever appeared) aren't packages.
+    // The real sumdb layout is `cache/download/sumdb/...` without any
+    // `.zip`, but guard anyway. This check uses the tight
+    // `download/sumdb` adjacency, NOT any path component named `sumdb`.
+    if is_under_cache_sumdb(path) {
         return None;
     }
     let (module, version) = parse_download_zip(path)?;
@@ -193,8 +226,19 @@ pub fn pre_delete(path: &Path) -> Result<(), String> {
 fn chmod_plus_w_recursive(path: &Path) {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
-    // Set the entry itself writable first so we can descend into it.
+    // symlink_metadata does NOT follow symlinks — we inspect the
+    // link itself. fs::set_permissions, however, DOES follow on
+    // Unix, so we must explicitly skip symlinks: a malicious or
+    // accidental symlink inside the module tree pointing at
+    // `/etc`, `~/.ssh`, or another cache must not get its target
+    // chmod'd via our walk. Skipping is safe — Go never creates
+    // symlinks in the module cache, so no real Go tree contains
+    // them; if one does, it's something the user (or an attacker)
+    // put there and we shouldn't escalate its permissions.
     if let Ok(metadata) = fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() {
+            return;
+        }
         let mode = metadata.permissions().mode();
         // Add owner write (0o200). Leave group/other bits untouched.
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode | 0o200));
@@ -373,6 +417,51 @@ mod tests {
         }
     }
 
+    // L1 edge cases: module path segments that happen to match our
+    // special-case component names must still produce a semantic name
+    // and PackageId. Go module path elements allow `letter`, `digit`,
+    // `.`, `-`, `_`, `~` — so `go-build`, `sumdb`, `download` are all
+    // legal path elements.
+
+    #[test]
+    fn semantic_name_module_named_go_build_is_not_suppressed() {
+        // github.com/foo/go-build is a valid Go module path. The .zip
+        // must produce a semantic name (build-cache classification
+        // only applies when the path is actually under a GOCACHE root).
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/foo/go-build/@v/v1.0.0.zip",
+        );
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/foo/go-build v1.0.0".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_module_named_sumdb_is_not_suppressed() {
+        // `sumdb` is a legal module-path segment too.
+        let path =
+            PathBuf::from("/Users/j/go/pkg/mod/cache/download/example.com/sumdb/@v/v0.1.0.zip");
+        assert_eq!(
+            semantic_name(&path),
+            Some("example.com/sumdb v0.1.0".into())
+        );
+    }
+
+    #[test]
+    fn semantic_name_module_named_download_is_not_suppressed() {
+        // A module literally named `download` used to trip
+        // parse_download_zip's loop (it broke on the first `download`
+        // it saw).
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/foo/download/@v/v2.0.0.zip",
+        );
+        assert_eq!(
+            semantic_name(&path),
+            Some("github.com/foo/download v2.0.0".into())
+        );
+    }
+
     // --- package_id ---
 
     #[test]
@@ -441,6 +530,24 @@ mod tests {
             "/Users/j/go/pkg/mod/cache/download/sumdb/sum.golang.org/lookup/github.com/foo/bar@v1.0.0",
         );
         assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_module_named_go_build_is_not_suppressed() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/foo/go-build/@v/v1.0.0.zip",
+        );
+        let id = package_id(&path).expect("expected PackageId for module named 'go-build'");
+        assert_eq!(id.name, "github.com/foo/go-build");
+        assert_eq!(id.version, "v1.0.0");
+    }
+
+    #[test]
+    fn package_id_module_named_sumdb_is_not_suppressed() {
+        let path =
+            PathBuf::from("/Users/j/go/pkg/mod/cache/download/example.com/sumdb/@v/v0.1.0.zip");
+        let id = package_id(&path).expect("expected PackageId for module named 'sumdb'");
+        assert_eq!(id.name, "example.com/sumdb");
     }
 
     // --- metadata ---
@@ -548,5 +655,39 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let ghost = tmp.path().join("pkg/mod/does-not-exist");
         assert!(pre_delete(&ghost).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pre_delete_does_not_follow_symlinks_outside_subtree() {
+        // Security guard: a module tree containing a symlink pointing
+        // OUTSIDE the subtree must not be chmod'd via that symlink.
+        // Rust's fs::set_permissions follows symlinks on Unix, so the
+        // hook must skip them explicitly.
+        //
+        // We exercise the bug by freezing an outside file at a precise
+        // mode (0o400) and pointing a symlink DIRECTLY at the file. If
+        // the hook follows the link, fs::set_permissions adds 0o200
+        // (owner-write) to the file — observable via a post-mode check.
+        use std::fs;
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let tmp = tempfile::tempdir().unwrap();
+        let outside_file = tmp.path().join("do-not-touch.txt");
+        fs::write(&outside_file, "keep").unwrap();
+        fs::set_permissions(&outside_file, fs::Permissions::from_mode(0o400)).unwrap();
+
+        let module = tmp.path().join("pkg/mod/example.com/mod@v1.0.0");
+        fs::create_dir_all(&module).unwrap();
+        let trap = module.join("escape.txt");
+        // Symlink inside the module pointing directly at the file.
+        symlink(&outside_file, &trap).unwrap();
+
+        pre_delete(&module).expect("pre_delete should succeed");
+
+        let after_mode = fs::metadata(&outside_file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            after_mode, 0o400,
+            "symlink target was chmod'd by pre_delete — hook follows symlinks out of the subtree"
+        );
     }
 }

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -171,8 +171,50 @@ pub fn package_id(path: &Path) -> Option<super::PackageId> {
     })
 }
 
-pub fn pre_delete(_path: &Path) -> Result<(), String> {
+/// Prepare a subtree under the Go cache for deletion by stripping
+/// read-only flags. Go `chmod -R -w`'s the extracted module tree
+/// (`pkg/mod/<module>@<version>/`), so `remove_dir_all` fails without
+/// this step.
+///
+/// On the build cache (`go-build/`) this is a no-op because Go keeps
+/// those files writable — but we still walk safely: any per-entry
+/// chmod failure is swallowed (the subsequent remove_dir_all will
+/// produce the more informative error). A missing path is OK too —
+/// the caller surfaces the real error.
+pub fn pre_delete(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    chmod_plus_w_recursive(path);
     Ok(())
+}
+
+#[cfg(unix)]
+fn chmod_plus_w_recursive(path: &Path) {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    // Set the entry itself writable first so we can descend into it.
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        let mode = metadata.permissions().mode();
+        // Add owner write (0o200). Leave group/other bits untouched.
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode | 0o200));
+        if metadata.is_dir()
+            && let Ok(entries) = fs::read_dir(path)
+        {
+            for entry in entries.flatten() {
+                chmod_plus_w_recursive(&entry.path());
+            }
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn chmod_plus_w_recursive(_path: &Path) {
+    // Windows / other platforms: Go doesn't ship on the unsupported
+    // ones we care about, and std::fs::remove_dir_all on Windows
+    // handles read-only files via a compatibility path since Rust
+    // 1.77. Leave this as a no-op rather than maintain a parallel
+    // implementation.
 }
 
 /// Decode Go's on-disk bang-escape scheme for module paths.
@@ -445,5 +487,65 @@ mod tests {
             "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.zip",
         );
         assert!(metadata(&path).is_empty());
+    }
+
+    // --- pre_delete ---
+    //
+    // Go chmod -w's the extracted module tree (cache/download/ keeps
+    // its zips writable). Without a pre-delete +w walk,
+    // remove_dir_all fails on those directories.
+
+    #[cfg(unix)]
+    #[test]
+    fn pre_delete_chmods_read_only_module_subtree() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let module_dir = tmp
+            .path()
+            .join("pkg/mod/github.com/stretchr/testify@v1.8.4");
+        fs::create_dir_all(&module_dir).unwrap();
+        let file = module_dir.join("README.md");
+        fs::write(&file, "readme").unwrap();
+
+        // Simulate Go's chmod -R -w on the module tree.
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o444)).unwrap();
+        fs::set_permissions(&module_dir, fs::Permissions::from_mode(0o555)).unwrap();
+        assert!(
+            !file.metadata().unwrap().permissions().readonly() == false,
+            "sanity: file should be read-only before pre_delete runs"
+        );
+        // (Write flag is off on the file.)
+        assert!(fs::write(&file, "still writable?").is_err());
+
+        // Run the hook.
+        assert!(pre_delete(&module_dir).is_ok());
+
+        // Now both dir and file should be writable; remove_dir_all should succeed.
+        assert!(fs::write(&file, "ok now").is_ok());
+        assert!(fs::remove_dir_all(&module_dir).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pre_delete_on_build_cache_path_is_noop() {
+        use std::fs;
+        let tmp = tempfile::tempdir().unwrap();
+        let build_dir = tmp.path().join("Library/Caches/go-build/ab");
+        fs::create_dir_all(&build_dir).unwrap();
+        let file = build_dir.join("abcdef-d");
+        fs::write(&file, "").unwrap();
+        // Should succeed and not mess with permissions.
+        assert!(pre_delete(&build_dir).is_ok());
+    }
+
+    #[test]
+    fn pre_delete_on_nonexistent_path_is_ok() {
+        // Don't error on paths that don't exist — the caller is about
+        // to try remove_dir_all anyway and that will produce a more
+        // informative error if the path truly is wrong.
+        let tmp = tempfile::tempdir().unwrap();
+        let ghost = tmp.path().join("pkg/mod/does-not-exist");
+        assert!(pre_delete(&ghost).is_ok());
     }
 }

--- a/src/providers/go_mod.rs
+++ b/src/providers/go_mod.rs
@@ -118,8 +118,24 @@ pub fn metadata(_path: &Path) -> Vec<MetadataField> {
     Vec::new()
 }
 
-pub fn package_id(_path: &Path) -> Option<super::PackageId> {
-    None
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    // Dedup canonical file (L9): `cache/download/<module>/@v/<version>.{zip,info,mod,ziphash}`
+    // produces four sibling files per package. Only `.zip` is the
+    // identity source — the others sit alongside.
+    let name = path.file_name()?.to_string_lossy().to_string();
+    if !name.ends_with(".zip") {
+        return None;
+    }
+    // sumdb entries live under cache/download/ but aren't packages.
+    if path_has_component(path, "sumdb") {
+        return None;
+    }
+    let (module, version) = parse_download_zip(path)?;
+    Some(super::PackageId {
+        ecosystem: "Go",
+        name: module,
+        version,
+    })
 }
 
 pub fn pre_delete(_path: &Path) -> Result<(), String> {
@@ -280,5 +296,75 @@ mod tests {
         for p in ["/Users/j/go/pkg/mod", "/Users/j/Library/Caches/go-build"] {
             assert_eq!(semantic_name(&PathBuf::from(p)), None, "{p}");
         }
+    }
+
+    // --- package_id ---
+
+    #[test]
+    fn package_id_from_zip() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.zip",
+        );
+        let id = package_id(&path).expect("expected PackageId");
+        assert_eq!(id.ecosystem, "Go");
+        assert_eq!(id.name, "github.com/stretchr/testify");
+        assert_eq!(id.version, "v1.8.4");
+    }
+
+    #[test]
+    fn package_id_module_path_is_decoded() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/!uber-go/zap/@v/v1.27.0.zip",
+        );
+        let id = package_id(&path).expect("expected PackageId");
+        assert_eq!(id.name, "github.com/Uber-go/zap");
+        assert_eq!(id.version, "v1.27.0");
+    }
+
+    #[test]
+    fn package_id_from_info_returns_none() {
+        // L9: dedup canonical-file guard — only .zip produces a PackageId.
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.info",
+        );
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_from_mod_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.mod",
+        );
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_from_ziphash_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.ziphash",
+        );
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_from_extracted_dir_returns_none() {
+        // Extracted dir shares the same (module, version); counting it
+        // would double-count. Only the .zip produces identity.
+        let path = PathBuf::from("/Users/j/go/pkg/mod/github.com/stretchr/testify@v1.8.4");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_from_build_cache_entry_returns_none() {
+        let path = PathBuf::from("/Users/j/Library/Caches/go-build/ab/abcdef-d");
+        assert_eq!(package_id(&path), None);
+    }
+
+    #[test]
+    fn package_id_from_sumdb_returns_none() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/sumdb/sum.golang.org/lookup/github.com/foo/bar@v1.0.0",
+        );
+        assert_eq!(package_id(&path), None);
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1673,6 +1673,44 @@ mod tests {
         );
     }
 
+    // --- pre_delete default dispatch ---
+
+    #[test]
+    fn pre_delete_default_is_ok_for_every_non_go_cache_kind() {
+        // Regression guard: any CacheKind without a dedicated hook
+        // must fall through the _ arm returning Ok(()). A buggy arm
+        // here would block deletes globally.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().to_path_buf();
+        for kind in [
+            CacheKind::HuggingFace,
+            CacheKind::Pip,
+            CacheKind::Uv,
+            CacheKind::Npm,
+            CacheKind::Homebrew,
+            CacheKind::Cargo,
+            CacheKind::PreCommit,
+            CacheKind::Whisper,
+            CacheKind::Gh,
+            CacheKind::Torch,
+            CacheKind::Chroma,
+            CacheKind::Prisma,
+            CacheKind::Yarn,
+            CacheKind::Pnpm,
+            CacheKind::Bun,
+            CacheKind::Maven,
+            CacheKind::Gradle,
+            CacheKind::SwiftPm,
+            CacheKind::Xcode,
+            CacheKind::Unknown,
+        ] {
+            assert!(
+                pre_delete(kind, &path).is_ok(),
+                "{kind:?} pre_delete must default to Ok(())"
+            );
+        }
+    }
+
     // --- Go detect ---
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -274,6 +274,7 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
         CacheKind::Yarn => Some(format!("yarn add {name}@{version}")),
         CacheKind::Pnpm => Some(format!("pnpm add {name}@{version}")),
         CacheKind::Bun => Some(format!("bun add {name}@{version}")),
+        CacheKind::Go => Some(format!("go get {name}@{version}")),
         _ => None,
     }
 }
@@ -404,6 +405,20 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
                 SafetyLevel::Caution
             } else {
                 SafetyLevel::Safe
+            }
+        }
+        CacheKind::Go => {
+            // Module cache (pkg/mod) → Safe (re-resolvable from
+            // proxy.golang.org / VCS). Everything else classified as
+            // Go (build cache go-build, or any unknown-layout path) →
+            // Caution (cold rebuild cost for the build cache;
+            // conservative default for unknown subtrees). Component
+            // matching rejects L1 confusable suffixes like
+            // `pkg/mod-backup`.
+            if has_adjacent_components(path, "pkg", "mod") {
+                SafetyLevel::Safe
+            } else {
+                SafetyLevel::Caution
             }
         }
         CacheKind::Unknown => SafetyLevel::Caution,
@@ -1615,6 +1630,47 @@ mod tests {
         // L1: DerivedData-backup must not be classified as Caution-DerivedData.
         let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData-backup/junk");
         assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+    }
+
+    // --- Go safety ---
+
+    #[test]
+    fn safety_go_module_cache_is_safe() {
+        let path = PathBuf::from(
+            "/Users/j/go/pkg/mod/cache/download/github.com/stretchr/testify/@v/v1.8.4.zip",
+        );
+        assert_eq!(safety(CacheKind::Go, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_go_module_cache_extracted_is_safe() {
+        let path = PathBuf::from("/Users/j/go/pkg/mod/github.com/stretchr/testify@v1.8.4");
+        assert_eq!(safety(CacheKind::Go, &path), SafetyLevel::Safe);
+    }
+
+    #[test]
+    fn safety_go_build_cache_is_caution() {
+        let path = PathBuf::from("/Users/j/Library/Caches/go-build/ab/abcdef-d");
+        assert_eq!(safety(CacheKind::Go, &path), SafetyLevel::Caution);
+    }
+
+    #[test]
+    fn safety_go_rejects_confusable_pkg_mod_backup() {
+        // L1: pkg/mod-backup must not be classified as module-cache Safe.
+        // Falls through to the Go default (Caution) since neither
+        // pkg/mod nor go-build matches.
+        let path = PathBuf::from("/Users/j/go/pkg/mod-backup/foo");
+        assert_eq!(safety(CacheKind::Go, &path), SafetyLevel::Caution);
+    }
+
+    // --- Go upgrade_command ---
+
+    #[test]
+    fn upgrade_command_go_emits_go_get() {
+        assert_eq!(
+            upgrade_command(CacheKind::Go, "github.com/stretchr/testify", "v1.8.4"),
+            Some("go get github.com/stretchr/testify@v1.8.4".into())
+        );
     }
 
     // --- Go detect ---

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,6 +3,7 @@ pub mod cargo;
 pub mod chroma;
 pub mod generic;
 pub mod gh;
+pub mod go_mod;
 pub mod gradle;
 pub mod homebrew;
 pub mod huggingface;
@@ -81,6 +82,7 @@ pub fn detect(path: &Path) -> CacheKind {
         ".m2" => return CacheKind::Maven,
         ".gradle" => return CacheKind::Gradle,
         "org.swift.swiftpm" => return CacheKind::SwiftPm,
+        "go-build" => return CacheKind::Go,
         _ => {}
     }
 
@@ -136,6 +138,7 @@ pub fn detect(path: &Path) -> CacheKind {
                 return CacheKind::Cargo;
             }
             "org.swift.swiftpm" => return CacheKind::SwiftPm,
+            "go-build" => return CacheKind::Go,
             _ => {}
         }
     }
@@ -149,6 +152,16 @@ pub fn detect(path: &Path) -> CacheKind {
         || has_adjacent_components(path, "CoreSimulator", "Caches")
     {
         return CacheKind::Xcode;
+    }
+
+    // Go module cache: `<GOPATH>/pkg/mod`. Adjacent-component match on
+    // `pkg/mod` is enough — `pkg` is generic enough that we need the
+    // `mod` follow-on to avoid false positives, and L1 rejects
+    // `pkg/mod-backup` because the literal component after `pkg` must
+    // be exactly `mod`. `go-build` is covered via direct-name match
+    // above.
+    if has_adjacent_components(path, "pkg", "mod") {
+        return CacheKind::Go;
     }
 
     CacheKind::Unknown
@@ -176,6 +189,7 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
         CacheKind::Gradle => gradle::semantic_name(path),
         CacheKind::SwiftPm => swiftpm::semantic_name(path),
         CacheKind::Xcode => xcode::semantic_name(path),
+        CacheKind::Go => go_mod::semantic_name(path),
         CacheKind::Unknown => None,
     }
 }
@@ -202,6 +216,7 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
         CacheKind::Gradle => gradle::metadata(path),
         CacheKind::SwiftPm => swiftpm::metadata(path),
         CacheKind::Xcode => xcode::metadata(path),
+        CacheKind::Go => go_mod::metadata(path),
         CacheKind::Unknown => generic::metadata(path),
     }
 }
@@ -224,6 +239,7 @@ pub fn package_id(kind: CacheKind, path: &Path) -> Option<PackageId> {
         CacheKind::Bun => bun::package_id(path),
         CacheKind::Maven => maven::package_id(path),
         CacheKind::Gradle => gradle::package_id(path),
+        CacheKind::Go => go_mod::package_id(path),
         _ => None,
     }
 }
@@ -392,6 +408,20 @@ pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
         }
         CacheKind::Unknown => SafetyLevel::Caution,
         _ => SafetyLevel::Safe,
+    }
+}
+
+/// Custodial setup before the tree attempts `remove_dir_all` on a cache
+/// subtree. Default is a no-op; providers override when the filesystem
+/// needs preparation before removal (e.g. stripping read-only flags on
+/// Go's module cache — Go `chmod -w`'s extracted modules by design).
+///
+/// A hook error is surfaced as the existing `errored` counter in the
+/// delete status line.
+pub fn pre_delete(kind: CacheKind, path: &Path) -> Result<(), String> {
+    match kind {
+        CacheKind::Go => go_mod::pre_delete(path),
+        _ => Ok(()),
     }
 }
 
@@ -1585,5 +1615,66 @@ mod tests {
         // L1: DerivedData-backup must not be classified as Caution-DerivedData.
         let path = PathBuf::from("/Users/j/Library/Developer/Xcode/DerivedData-backup/junk");
         assert_eq!(safety(CacheKind::Xcode, &path), SafetyLevel::Safe);
+    }
+
+    // --- Go detect ---
+
+    #[test]
+    fn detect_go_build_cache_root() {
+        assert_eq!(
+            detect(&PathBuf::from("/Users/j/Library/Caches/go-build")),
+            CacheKind::Go
+        );
+    }
+
+    #[test]
+    fn detect_go_build_cache_deep_path() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/Library/Caches/go-build/ab/abcdef123456-d"
+            )),
+            CacheKind::Go
+        );
+    }
+
+    #[test]
+    fn detect_go_module_cache_pkg_mod_root() {
+        assert_eq!(detect(&PathBuf::from("/Users/j/go/pkg/mod")), CacheKind::Go);
+    }
+
+    #[test]
+    fn detect_go_module_cache_download_zip() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/j/go/pkg/mod/cache/download/github.com/!uber-go/zap/@v/v1.27.0.zip"
+            )),
+            CacheKind::Go
+        );
+    }
+
+    #[test]
+    fn detect_go_rejects_pkg_mod_backup() {
+        // L1: pkg-mod-backup or pkg/mod-backup must not match.
+        assert_ne!(
+            detect(&PathBuf::from("/Users/j/go/pkg/mod-backup/foo")),
+            CacheKind::Go
+        );
+    }
+
+    #[test]
+    fn detect_go_rejects_go_build_backup() {
+        assert_ne!(
+            detect(&PathBuf::from("/Users/j/Library/Caches/go-build-backup")),
+            CacheKind::Go
+        );
+    }
+
+    #[test]
+    fn detect_go_rejects_unrelated_mod_dir() {
+        // Random `mod/` not under a `pkg/` parent must not match.
+        assert_ne!(
+            detect(&PathBuf::from("/tmp/random/mod/stuff")),
+            CacheKind::Go
+        );
     }
 }

--- a/src/security/registry.rs
+++ b/src/security/registry.rs
@@ -42,6 +42,63 @@ pub fn parse_maven_latest(xml: &str) -> Option<String> {
     extract_tag(xml, "release").or_else(|| extract_tag(xml, "latest"))
 }
 
+/// Is `v` a Go pseudo-version of the form `vX.Y.Z-YYYYMMDDHHMMSS-<12hex>`?
+/// Used to filter commit-timestamp placeholders out of proxy.golang.org's
+/// /@v/list output so users aren't told their stable v1.2.3 is "outdated"
+/// compared to some nameless commit from last week.
+fn is_go_pseudo_version(v: &str) -> bool {
+    let parts: Vec<&str> = v.split('-').collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    let ts = parts[parts.len() - 2];
+    let hash = parts[parts.len() - 1];
+    ts.len() == 14
+        && ts.chars().all(|c| c.is_ascii_digit())
+        && hash.len() == 12
+        && hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Parse `proxy.golang.org/<module>/@v/list` — newline-delimited versions.
+/// Picks the highest non-pseudo, non-`+incompatible` version. Falls back to
+/// `+incompatible` only when that's all on offer; falls back to pseudo only
+/// when no real tags exist at all.
+pub fn parse_go_proxy_list(body: &str) -> Option<String> {
+    let all: Vec<&str> = body
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    let pick = |candidates: Vec<&str>| -> Option<String> {
+        candidates
+            .into_iter()
+            .max_by(|a, b| crate::security::osv::compare_versions(a, b))
+            .map(|s| s.to_string())
+    };
+
+    let preferred: Vec<&str> = all
+        .iter()
+        .copied()
+        .filter(|l| !is_go_pseudo_version(l))
+        .filter(|l| !l.ends_with("+incompatible"))
+        .collect();
+    if let Some(v) = pick(preferred) {
+        return Some(v);
+    }
+
+    let non_pseudo: Vec<&str> = all
+        .iter()
+        .copied()
+        .filter(|l| !is_go_pseudo_version(l))
+        .collect();
+    if let Some(v) = pick(non_pseudo) {
+        return Some(v);
+    }
+
+    pick(all)
+}
+
 /// Build the registry URL for a given package, or `None` if the ecosystem is unsupported.
 pub fn build_registry_url(pkg: &crate::providers::PackageId) -> Option<String> {
     match pkg.ecosystem {
@@ -56,8 +113,32 @@ pub fn build_registry_url(pkg: &crate::providers::PackageId) -> Option<String> {
                 "https://repo1.maven.org/maven2/{group_path}/{artifact}/maven-metadata.xml"
             ))
         }
+        "Go" => {
+            // pkg.name is the decoded module path (e.g.
+            // `github.com/Uber-go/zap`). proxy.golang.org wants the
+            // on-disk escaped form for case-sensitivity, so we re-encode
+            // uppercase letters as `!<lowercase>`.
+            let encoded = encode_go_module_path(&pkg.name);
+            Some(format!("https://proxy.golang.org/{encoded}/@v/list"))
+        }
         _ => None,
     }
+}
+
+/// Re-apply Go's bang-escape: uppercase ASCII → `!<lowercase>`. Inverse
+/// of go_mod::decode_module_path. Needed when building proxy URLs
+/// because the proxy stores modules under their escaped names.
+fn encode_go_module_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_uppercase() {
+            out.push('!');
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Parse the registry JSON response for the given ecosystem.
@@ -67,6 +148,7 @@ pub fn parse_registry_response(ecosystem: &str, body: &str) -> Option<String> {
         "crates.io" => parse_crates_io_latest(body),
         "npm" => parse_npm_latest(body),
         "Maven" => parse_maven_latest(body),
+        "Go" => parse_go_proxy_list(body),
         _ => None,
     }
 }
@@ -294,5 +376,84 @@ mod tests {
             parse_registry_response("Maven", xml),
             Some("2.0.0".to_string())
         );
+    }
+
+    // --- Go proxy (proxy.golang.org /@v/list) ---
+
+    #[test]
+    fn parse_go_proxy_list_picks_highest_semver() {
+        let body = "v1.0.0\nv1.5.2\nv1.2.0\nv1.10.1\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.10.1".into()));
+    }
+
+    #[test]
+    fn parse_go_proxy_list_skips_pseudo_versions() {
+        // A pseudo-version is v0.0.0-<14digits>-<12hex>. It must NOT
+        // win over a real tag.
+        let body = "v1.5.0\nv0.0.0-20210101120000-abcdef123456\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.5.0".into()));
+    }
+
+    #[test]
+    fn parse_go_proxy_list_returns_pseudo_when_nothing_else() {
+        // If every version is a pseudo-version, fall back to the
+        // highest one so the user still sees something.
+        let body = "v0.0.0-20210101120000-abcdef123456\nv0.0.0-20220202130000-beefcafe1234\n";
+        assert_eq!(
+            parse_go_proxy_list(body),
+            Some("v0.0.0-20220202130000-beefcafe1234".into())
+        );
+    }
+
+    #[test]
+    fn parse_go_proxy_list_prefers_non_incompatible() {
+        let body = "v1.5.0\nv2.0.0+incompatible\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.5.0".into()));
+    }
+
+    #[test]
+    fn parse_go_proxy_list_returns_incompatible_when_only_option() {
+        let body = "v2.0.0+incompatible\nv2.1.0+incompatible\n";
+        assert_eq!(
+            parse_go_proxy_list(body),
+            Some("v2.1.0+incompatible".into())
+        );
+    }
+
+    #[test]
+    fn parse_go_proxy_list_handles_pre_release() {
+        // L3: pre-release (-alpha.1) must compare less than stable.
+        let body = "v1.5.0\nv1.6.0-alpha.1\nv1.5.1\n";
+        // v1.5.0 < v1.5.1 < v1.6.0-alpha.1 (in lex/semver sort).
+        // compare_versions treats -alpha as pre-release of 1.6.0,
+        // which is *less* than the eventual 1.6.0 but *greater* than
+        // 1.5.x. So the max is v1.6.0-alpha.1.
+        assert_eq!(parse_go_proxy_list(body), Some("v1.6.0-alpha.1".into()));
+    }
+
+    #[test]
+    fn parse_go_proxy_list_empty_body_returns_none() {
+        assert_eq!(parse_go_proxy_list(""), None);
+    }
+
+    #[test]
+    fn parse_go_proxy_list_ignores_blank_lines() {
+        let body = "\nv1.0.0\n\nv1.1.0\n\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.1.0".into()));
+    }
+
+    #[test]
+    fn build_registry_url_go_emits_proxy_url() {
+        let pkg = pkg("Go", "github.com/stretchr/testify");
+        assert_eq!(
+            build_registry_url(&pkg),
+            Some("https://proxy.golang.org/github.com/stretchr/testify/@v/list".into())
+        );
+    }
+
+    #[test]
+    fn parse_registry_response_dispatches_to_go() {
+        let body = "v1.0.0\nv1.1.0\n";
+        assert_eq!(parse_registry_response("Go", body), Some("v1.1.0".into()));
     }
 }

--- a/src/security/registry.rs
+++ b/src/security/registry.rs
@@ -42,21 +42,31 @@ pub fn parse_maven_latest(xml: &str) -> Option<String> {
     extract_tag(xml, "release").or_else(|| extract_tag(xml, "latest"))
 }
 
-/// Is `v` a Go pseudo-version of the form `vX.Y.Z-YYYYMMDDHHMMSS-<12hex>`?
-/// Used to filter commit-timestamp placeholders out of proxy.golang.org's
-/// /@v/list output so users aren't told their stable v1.2.3 is "outdated"
-/// compared to some nameless commit from last week.
+/// Is `v` a Go pseudo-version? Per
+/// https://go.dev/ref/mod#pseudo-versions there are three forms:
+///   1. `vX.0.0-YYYYMMDDHHMMSS-<12hex>`                        (no tagged release)
+///   2. `vX.Y.Z-pre.0.YYYYMMDDHHMMSS-<12hex>`                  (after a tagged pre-release)
+///   3. `vX.Y.(Z+1)-0.YYYYMMDDHHMMSS-<12hex>`                  (after a tagged release)
+///
+/// The common shape: the last two `-`-delimited segments are
+/// `[<prerelease>.]YYYYMMDDHHMMSS` and `<12hex>`. The 14-digit
+/// timestamp is always the final dot-separated piece of the
+/// second-to-last `-` segment.
 fn is_go_pseudo_version(v: &str) -> bool {
     let parts: Vec<&str> = v.split('-').collect();
     if parts.len() < 3 {
         return false;
     }
-    let ts = parts[parts.len() - 2];
     let hash = parts[parts.len() - 1];
-    ts.len() == 14
-        && ts.chars().all(|c| c.is_ascii_digit())
-        && hash.len() == 12
-        && hash.chars().all(|c| c.is_ascii_hexdigit())
+    if hash.len() != 12 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    // The timestamp chunk may be bare (`YYYYMMDDHHMMSS`) or suffixed
+    // (`0.YYYYMMDDHHMMSS`, `pre.0.YYYYMMDDHHMMSS`). Take the last
+    // dot-separated piece and check the 14-digit rule.
+    let ts_chunk = parts[parts.len() - 2];
+    let ts = ts_chunk.rsplit('.').next().unwrap_or(ts_chunk);
+    ts.len() == 14 && ts.chars().all(|c| c.is_ascii_digit())
 }
 
 /// Parse `proxy.golang.org/<module>/@v/list` — newline-delimited versions.
@@ -403,6 +413,24 @@ mod tests {
             parse_go_proxy_list(body),
             Some("v0.0.0-20220202130000-beefcafe1234".into())
         );
+    }
+
+    #[test]
+    fn parse_go_proxy_list_skips_pseudo_version_after_tagged_release_form() {
+        // Form 3 per Go pseudo-version spec:
+        // vX.Y.(Z+1)-0.YYYYMMDDHHMMSS-<12hex>
+        // (used when there was an earlier tagged release).
+        let body = "v1.5.0\nv1.5.1-0.20210101120000-abcdef123456\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.5.0".into()));
+    }
+
+    #[test]
+    fn parse_go_proxy_list_skips_pseudo_version_after_prerelease_form() {
+        // Form 2 per Go pseudo-version spec:
+        // vX.Y.Z-pre.0.YYYYMMDDHHMMSS-<12hex>
+        // (used when there was an earlier tagged pre-release).
+        let body = "v1.5.0\nv1.5.1-beta.0.20210101120000-abcdef123456\n";
+        assert_eq!(parse_go_proxy_list(body), Some("v1.5.0".into()));
     }
 
     #[test]

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -22,6 +22,7 @@ pub enum CacheKind {
     Gradle,
     SwiftPm,
     Xcode,
+    Go,
     #[default]
     Unknown,
 }
@@ -48,6 +49,7 @@ impl CacheKind {
             Self::Gradle => "Gradle",
             Self::SwiftPm => "Swift Package Manager",
             Self::Xcode => "Xcode",
+            Self::Go => "Go",
             Self::Unknown => "",
         }
     }
@@ -77,6 +79,7 @@ impl CacheKind {
             }
             Self::SwiftPm => "Swift Package Manager — cached git clones, artifacts, and manifests",
             Self::Xcode => "Xcode build caches — DerivedData, iOS DeviceSupport, Simulator",
+            Self::Go => "Go module cache and build cache",
             Self::Unknown => "",
         }
     }
@@ -102,6 +105,7 @@ impl CacheKind {
             Self::Gradle => "https://gradle.org",
             Self::SwiftPm => "https://www.swift.org/package-manager/",
             Self::Xcode => "https://developer.apple.com/xcode/",
+            Self::Go => "https://go.dev",
             Self::Unknown => "",
         }
     }
@@ -258,6 +262,7 @@ mod tests {
             CacheKind::Gradle,
             CacheKind::SwiftPm,
             CacheKind::Xcode,
+            CacheKind::Go,
         ];
         for kind in &all {
             assert!(!kind.label().is_empty(), "{:?} label empty", kind);
@@ -302,5 +307,12 @@ mod tests {
         assert_eq!(CacheKind::Xcode.label(), "Xcode");
         assert!(!CacheKind::Xcode.description().is_empty());
         assert_eq!(CacheKind::Xcode.url(), "https://developer.apple.com/xcode/");
+    }
+
+    #[test]
+    fn cache_kind_go_label_description_url() {
+        assert_eq!(CacheKind::Go.label(), "Go");
+        assert!(!CacheKind::Go.description().is_empty());
+        assert_eq!(CacheKind::Go.url(), "https://go.dev");
     }
 }

--- a/tests/e2e_go_provider.rs
+++ b/tests/e2e_go_provider.rs
@@ -22,7 +22,6 @@ use ccmd::providers::{self, SafetyLevel};
 use ccmd::tree::node::CacheKind;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use std::time::Duration;
 
 fn is_available(cmd: &str) -> bool {
     Command::new(cmd)
@@ -223,6 +222,4 @@ fn e2e_go_discovery_vuln_scan_version_check_and_delete() {
     drop(gomodcache);
     drop(gocache);
     drop(gopath);
-    // Silence unused Duration import (used for potential future timeouts).
-    let _ = Duration::from_secs(0);
 }

--- a/tests/e2e_go_provider.rs
+++ b/tests/e2e_go_provider.rs
@@ -1,0 +1,194 @@
+//! End-to-end test for the Go provider using a real `go` tool.
+//!
+//! Populates a scoped module cache via `go mod download` on an outdated,
+//! known-vulnerable module (`github.com/gin-gonic/gin v1.6.0`, CVE-2023-26125
+//! / CVE-2023-29401), then verifies:
+//!   1. `ccmd::scanner::discover_packages` extracts the correct PackageId.
+//!   2. `ccmd::security::scan_vulns` (hits osv.dev) detects ≥1 vuln.
+//!   3. `ccmd::security::check_versions` (hits proxy.golang.org /@v/list)
+//!      reports the module as outdated.
+//!   4. `providers::pre_delete` + `remove_dir_all` succeeds on Go's
+//!      chmod-R-w module tree (the whole motivation for the hook).
+//!
+//! All state lives in a scoped tempdir — `GOMODCACHE` / `GOCACHE` / `GOPATH`
+//! all redirect there, so we never touch the developer's real `~/go`.
+//! Test SKIPs cleanly if `go` is absent.
+//!
+//! Run with: cargo test --features e2e --test e2e_go_provider -- --nocapture
+
+#![cfg(feature = "e2e")]
+
+use ccmd::providers::{self, SafetyLevel};
+use ccmd::tree::node::CacheKind;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn is_available(cmd: &str) -> bool {
+    Command::new(cmd)
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run(cmd: &str, args: &[&str], envs: &[(&str, &Path)], cwd: &Path) -> Result<(), String> {
+    let mut c = Command::new(cmd);
+    c.args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    for (k, v) in envs {
+        c.env(k, v);
+    }
+    let status = c.status().map_err(|e| format!("{cmd} {args:?}: {e}"))?;
+    if !status.success() {
+        return Err(format!("{cmd} {args:?} failed with {status}"));
+    }
+    Ok(())
+}
+
+/// Deliberately-vulnerable and deliberately-outdated Go module.
+/// gin v1.6.0 is both outdated (latest is v1.10+) and OSV-flagged for
+/// CVE-2023-26125 and CVE-2023-29401 among others.
+const GIN_VULN_MODULE: &str = "github.com/gin-gonic/gin";
+const GIN_VULN_VERSION: &str = "v1.6.0";
+
+#[test]
+fn e2e_go_discovery_vuln_scan_version_check_and_delete() {
+    if !is_available("go") {
+        eprintln!("SKIP: go not installed (install with `brew install go` or use CI)");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    // Preserve the real-world `pkg/mod` layout — detect() requires
+    // `pkg` as the immediate parent of `mod` via has_adjacent_components.
+    let gomodcache = tmp.path().join("pkg/mod");
+    let gocache = tmp.path().join("build");
+    let gopath = tmp.path().join("gopath");
+    let workdir = tmp.path().join("work");
+    std::fs::create_dir_all(&gomodcache).unwrap();
+    std::fs::create_dir_all(&gocache).unwrap();
+    std::fs::create_dir_all(&gopath).unwrap();
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    // Sanity: tempdir must be the only cache location used (#feedback_e2e_must_isolate).
+    assert!(
+        gomodcache.starts_with(tmp.path()),
+        "GOMODCACHE escaped tempdir: {gomodcache:?}"
+    );
+
+    let envs: &[(&str, &Path)] = &[
+        ("GOMODCACHE", gomodcache.as_path()),
+        ("GOCACHE", gocache.as_path()),
+        ("GOPATH", gopath.as_path()),
+    ];
+
+    // Initialise a throwaway module in the workdir so `go mod download` has context.
+    run("go", &["mod", "init", "ccmd-e2e-test"], envs, &workdir).expect("go mod init");
+    // Add the dep, then resolve — populates the module cache.
+    run(
+        "go",
+        &[
+            "mod",
+            "edit",
+            "-require",
+            &format!("{GIN_VULN_MODULE}@{GIN_VULN_VERSION}"),
+        ],
+        envs,
+        &workdir,
+    )
+    .expect("go mod edit");
+    run("go", &["mod", "download", GIN_VULN_MODULE], envs, &workdir).expect("go mod download");
+
+    // The download should have produced a .zip under cache/download/.
+    let zip_dir = gomodcache.join("cache/download/github.com/gin-gonic/gin/@v");
+    if !zip_dir.exists() {
+        // Dump what IS in the tempdir to help debugging env-var mis-wire.
+        eprintln!("GOMODCACHE contents after go mod download:");
+        fn dump(p: &Path, depth: usize) {
+            if depth > 4 {
+                return;
+            }
+            if let Ok(entries) = std::fs::read_dir(p) {
+                for e in entries.flatten() {
+                    eprintln!("  {}{}", "  ".repeat(depth), e.path().display());
+                    if e.path().is_dir() {
+                        dump(&e.path(), depth + 1);
+                    }
+                }
+            }
+        }
+        dump(&gomodcache, 0);
+        panic!("expected {zip_dir:?} after go mod download");
+    }
+    let zip_path = zip_dir.join(format!("{GIN_VULN_VERSION}.zip"));
+    assert!(zip_path.exists(), "expected {zip_path:?}");
+
+    // 1. Discover: the scanner should find gin with the expected identity.
+    let packages = ccmd::scanner::discover_packages(&[gomodcache.clone()]);
+    let gin = packages
+        .iter()
+        .find(|(_, id)| id.name == GIN_VULN_MODULE && id.ecosystem == "Go")
+        .expect(&format!(
+            "expected Go/{GIN_VULN_MODULE} in discovered packages, got {:?}",
+            packages
+                .iter()
+                .map(|(_, id)| (id.ecosystem, id.name.clone(), id.version.clone()))
+                .collect::<Vec<_>>()
+        ));
+    assert_eq!(gin.1.version, GIN_VULN_VERSION);
+
+    // 2. OSV vuln scan: proxy.golang.org / osv.dev agree this version is vulnerable.
+    let vuln_outcome = ccmd::security::scan_vulns(&packages);
+    let vuln_hit = vuln_outcome
+        .results
+        .iter()
+        .any(|(path, info)| path.to_string_lossy().contains("gin") && !info.vulns.is_empty());
+    assert!(
+        vuln_hit,
+        "expected OSV to flag gin v1.6.0; unscanned={}, results:\n{:#?}",
+        vuln_outcome.unscanned_packages, vuln_outcome.results
+    );
+
+    // 3. Version check: proxy.golang.org /@v/list should return something newer.
+    let outdated = ccmd::security::registry::check_latest(&gin.1)
+        .expect("check_latest should succeed for Go ecosystem");
+    let latest = outdated.expect("expected a latest version from proxy.golang.org");
+    // compare_versions strips the leading `v` for Go-style versions — if the
+    // returned version is strictly greater than v1.6.0, we're good.
+    assert!(
+        ccmd::security::osv::compare_versions(&latest, GIN_VULN_VERSION)
+            == std::cmp::Ordering::Greater,
+        "expected a version > {GIN_VULN_VERSION} from proxy, got {latest}"
+    );
+
+    // 4. Delete via pre_delete + remove_dir_all: verify the module tree goes
+    // away cleanly despite Go's chmod -R -w.
+    // Target the extracted module dir if it exists; otherwise the download dir.
+    let extracted_glob = gomodcache.join(format!("github.com/gin-gonic/gin@{GIN_VULN_VERSION}"));
+    let target = if extracted_glob.exists() {
+        extracted_glob
+    } else {
+        // `go mod download` sometimes stops at the zip without extracting.
+        // The zip dir itself is read-only too; still a valid test target.
+        zip_dir
+    };
+    assert_eq!(providers::detect(&target), CacheKind::Go);
+    assert_eq!(providers::safety(CacheKind::Go, &target), SafetyLevel::Safe);
+    providers::pre_delete(CacheKind::Go, &target).expect("pre_delete should succeed");
+    // Now the canonical delete path.
+    std::fs::remove_dir_all(&target).expect("remove_dir_all should succeed after pre_delete");
+
+    // Tempdir drops at scope exit → clean on green, preserved on red
+    // (we explicitly didn't register a cleanup for a failed run so the
+    // failure is inspectable).
+    let _ = tmp; // keep alive through the test
+    drop(gomodcache);
+    drop(gocache);
+    drop(gopath);
+    // Silence unused Duration import (used for potential future timeouts).
+    let _ = Duration::from_secs(0);
+}

--- a/tests/e2e_go_provider.rs
+++ b/tests/e2e_go_provider.rs
@@ -20,7 +20,7 @@
 
 use ccmd::providers::{self, SafetyLevel};
 use ccmd::tree::node::CacheKind;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -129,34 +129,66 @@ fn e2e_go_discovery_vuln_scan_version_check_and_delete() {
 
     // 1. Discover: the scanner should find gin with the expected identity.
     let packages = ccmd::scanner::discover_packages(&[gomodcache.clone()]);
+    eprintln!(
+        "[e2e] discover_packages returned {} entries",
+        packages.len()
+    );
     let gin = packages
         .iter()
         .find(|(_, id)| id.name == GIN_VULN_MODULE && id.ecosystem == "Go")
-        .expect(&format!(
-            "expected Go/{GIN_VULN_MODULE} in discovered packages, got {:?}",
-            packages
-                .iter()
-                .map(|(_, id)| (id.ecosystem, id.name.clone(), id.version.clone()))
-                .collect::<Vec<_>>()
-        ));
+        .unwrap_or_else(|| {
+            panic!(
+                "expected Go/{GIN_VULN_MODULE} in discovered packages, got {:?}",
+                packages
+                    .iter()
+                    .map(|(_, id)| (id.ecosystem, id.name.clone(), id.version.clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
     assert_eq!(gin.1.version, GIN_VULN_VERSION);
+    eprintln!(
+        "[e2e] found {} @ {} at {}",
+        gin.1.name,
+        gin.1.version,
+        gin.0.display()
+    );
 
     // 2. OSV vuln scan: proxy.golang.org / osv.dev agree this version is vulnerable.
     let vuln_outcome = ccmd::security::scan_vulns(&packages);
-    let vuln_hit = vuln_outcome
+    let cve_count: usize = vuln_outcome
         .results
         .iter()
-        .any(|(path, info)| path.to_string_lossy().contains("gin") && !info.vulns.is_empty());
+        .filter(|(path, _)| path.to_string_lossy().contains("gin"))
+        .map(|(_, info)| info.vulns.len())
+        .sum();
+    let cve_ids: Vec<String> = vuln_outcome
+        .results
+        .iter()
+        .filter(|(path, _)| path.to_string_lossy().contains("gin"))
+        .flat_map(|(_, info)| info.vulns.iter().map(|v| v.id.clone()))
+        .collect();
+    eprintln!(
+        "[e2e] OSV scanned {} package(s), {} unscanned; gin CVEs: {} ({})",
+        vuln_outcome.results.len(),
+        vuln_outcome.unscanned_packages,
+        cve_count,
+        cve_ids.join(", ")
+    );
     assert!(
-        vuln_hit,
+        cve_count > 0,
         "expected OSV to flag gin v1.6.0; unscanned={}, results:\n{:#?}",
-        vuln_outcome.unscanned_packages, vuln_outcome.results
+        vuln_outcome.unscanned_packages,
+        vuln_outcome.results
     );
 
     // 3. Version check: proxy.golang.org /@v/list should return something newer.
     let outdated = ccmd::security::registry::check_latest(&gin.1)
         .expect("check_latest should succeed for Go ecosystem");
     let latest = outdated.expect("expected a latest version from proxy.golang.org");
+    eprintln!(
+        "[e2e] proxy.golang.org latest for {}: {} (installed: {})",
+        gin.1.name, latest, GIN_VULN_VERSION
+    );
     // compare_versions strips the leading `v` for Go-style versions — if the
     // returned version is strictly greater than v1.6.0, we're good.
     assert!(
@@ -179,8 +211,10 @@ fn e2e_go_discovery_vuln_scan_version_check_and_delete() {
     assert_eq!(providers::detect(&target), CacheKind::Go);
     assert_eq!(providers::safety(CacheKind::Go, &target), SafetyLevel::Safe);
     providers::pre_delete(CacheKind::Go, &target).expect("pre_delete should succeed");
+    eprintln!("[e2e] pre_delete succeeded on {}", target.display());
     // Now the canonical delete path.
     std::fs::remove_dir_all(&target).expect("remove_dir_all should succeed after pre_delete");
+    eprintln!("[e2e] remove_dir_all succeeded — delete flow verified end-to-end");
 
     // Tempdir drops at scope exit → clean on green, preserved on red
     // (we explicitly didn't register a cleanup for a failed run so the

--- a/tests/integration_go.rs
+++ b/tests/integration_go.rs
@@ -1,0 +1,146 @@
+// Integration test: synthetic Go module + build cache fixtures
+// exercise the full detect → semantic_name → metadata → safety →
+// package_id pipeline.
+//
+// Tier-3 E2E (install real go, download a vulnerable module, verify
+// OSV + version-check fire) lives in tests/e2e_go_provider.rs and is
+// feature-gated on `e2e`.
+
+use ccmd::providers::{self, SafetyLevel};
+use ccmd::tree::node::CacheKind;
+use std::fs;
+
+#[test]
+fn go_module_cache_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let download = tmp
+        .path()
+        .join("go/pkg/mod/cache/download/github.com/stretchr/testify/@v");
+    fs::create_dir_all(&download).unwrap();
+    let zip = download.join("v1.8.4.zip");
+    fs::write(&zip, b"fake zip").unwrap();
+    fs::write(download.join("v1.8.4.info"), b"{}").unwrap();
+    fs::write(
+        download.join("v1.8.4.mod"),
+        b"module github.com/stretchr/testify\n",
+    )
+    .unwrap();
+
+    // detect
+    assert_eq!(providers::detect(&zip), CacheKind::Go);
+    assert_eq!(providers::detect(&download), CacheKind::Go);
+
+    // semantic_name decodes bang-escapes and joins module path
+    assert_eq!(
+        providers::semantic_name(CacheKind::Go, &zip),
+        Some("github.com/stretchr/testify v1.8.4".into())
+    );
+
+    // package_id only on .zip (dedup) — .info and .mod return None
+    let id = providers::package_id(CacheKind::Go, &zip).expect("expected PackageId");
+    assert_eq!(id.ecosystem, "Go");
+    assert_eq!(id.name, "github.com/stretchr/testify");
+    assert_eq!(id.version, "v1.8.4");
+    assert_eq!(
+        providers::package_id(CacheKind::Go, &download.join("v1.8.4.info")),
+        None
+    );
+    assert_eq!(
+        providers::package_id(CacheKind::Go, &download.join("v1.8.4.mod")),
+        None
+    );
+
+    // safety: module cache is Safe
+    assert_eq!(providers::safety(CacheKind::Go, &zip), SafetyLevel::Safe);
+}
+
+#[test]
+fn go_module_cache_bang_decoding_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    // !uber-go is the on-disk form of Uber-go.
+    let download = tmp
+        .path()
+        .join("go/pkg/mod/cache/download/github.com/!uber-go/zap/@v");
+    fs::create_dir_all(&download).unwrap();
+    let zip = download.join("v1.27.0.zip");
+    fs::write(&zip, b"fake zip").unwrap();
+
+    assert_eq!(providers::detect(&zip), CacheKind::Go);
+    assert_eq!(
+        providers::semantic_name(CacheKind::Go, &zip),
+        Some("github.com/Uber-go/zap v1.27.0".into())
+    );
+    let id = providers::package_id(CacheKind::Go, &zip).expect("expected PackageId");
+    assert_eq!(
+        id.name, "github.com/Uber-go/zap",
+        "package_id.name must be bang-decoded so OSV sees the real module path"
+    );
+}
+
+#[test]
+fn go_build_cache_pipeline() {
+    let tmp = tempfile::tempdir().unwrap();
+    let build = tmp.path().join("Library/Caches/go-build/ab");
+    fs::create_dir_all(&build).unwrap();
+    let blob = build.join("abcdef123456-d");
+    fs::write(&blob, b"build artifact").unwrap();
+
+    assert_eq!(providers::detect(&blob), CacheKind::Go);
+    // Content-addressed blobs have no semantic name.
+    assert_eq!(providers::semantic_name(CacheKind::Go, &blob), None);
+    // Not a package — no identity.
+    assert_eq!(providers::package_id(CacheKind::Go, &blob), None);
+    // Build cache is Caution (cold rebuild cost).
+    assert_eq!(
+        providers::safety(CacheKind::Go, &blob),
+        SafetyLevel::Caution
+    );
+}
+
+#[test]
+fn go_extracted_module_dir_is_safe_and_named_but_not_counted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let extracted = tmp
+        .path()
+        .join("go/pkg/mod/github.com/stretchr/testify@v1.8.4");
+    fs::create_dir_all(&extracted).unwrap();
+
+    assert_eq!(providers::detect(&extracted), CacheKind::Go);
+    assert_eq!(
+        providers::semantic_name(CacheKind::Go, &extracted),
+        Some("github.com/stretchr/testify v1.8.4".into())
+    );
+    // Dedup guard: extracted dir must NOT produce a PackageId
+    // (otherwise the zip + the extracted dir would double-count).
+    assert_eq!(providers::package_id(CacheKind::Go, &extracted), None);
+    assert_eq!(
+        providers::safety(CacheKind::Go, &extracted),
+        SafetyLevel::Safe
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn go_pre_delete_unblocks_remove_dir_all_on_read_only_module() {
+    // pre_delete's job: after Go has chmod -R -w'd the extracted
+    // module tree, remove_dir_all must still succeed. We don't test
+    // the "without pre_delete it would fail" sanity path because its
+    // outcome varies by filesystem (APFS sometimes tolerates it) —
+    // the positive assertion below is what matters.
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let module = tmp
+        .path()
+        .join("go/pkg/mod/github.com/stretchr/testify@v1.8.4");
+    fs::create_dir_all(&module).unwrap();
+    let readme = module.join("README.md");
+    fs::write(&readme, "docs").unwrap();
+
+    // Simulate Go's chmod -R -w.
+    fs::set_permissions(&readme, fs::Permissions::from_mode(0o444)).unwrap();
+    fs::set_permissions(&module, fs::Permissions::from_mode(0o555)).unwrap();
+
+    // Run the hook, then remove.
+    providers::pre_delete(CacheKind::Go, &module).expect("pre_delete should succeed");
+    fs::remove_dir_all(&module).expect("remove_dir_all should succeed after pre_delete");
+}


### PR DESCRIPTION
## Summary

New `CacheKind::Go` covering both the Go module cache (`$GOMODCACHE`, default `~/go/pkg/mod`) and the build cache (`$GOCACHE`, default `~/Library/Caches/go-build` / `~/.cache/go-build`). Module cache is Safe and gets the full OSV + version-check + upgrade-command pipeline; build cache is Caution (cold rebuild cost) and disk-hygiene only.

Ships alongside a new `providers::pre_delete` dispatch — the whole motivation for which is that Go `chmod -R -w`'s its extracted module tree, so `remove_dir_all` fails silently without a preparatory `chmod +w` walk. Default is `_ => Ok(())` so existing providers are unaffected.

## Notable design calls

- **Module-path bang-decoding**: Go escapes uppercase ASCII on disk (`github.com/Uber/zap` → `github.com/!uber/zap`) for case-insensitive-filesystem compat. Decoded at `semantic_name` / `package_id` so OSV sees the real module path; re-encoded when building the proxy.golang.org URL.
- **Pseudo-version filtering**: proxy.golang.org's `/@v/list` returns `vX.Y.Z-<14digits>-<12hex>` for untagged commits. These are filtered out of the "latest" determination (three-tier fallback: non-pseudo non-`+incompatible` → non-pseudo → any) so the outdated indicator doesn't point at a random last-week commit.
- **`.zip`-only dedup** (L9): `cache/download/<mod>/@v/<ver>.{zip,info,mod,ziphash}` produces four sibling files per package plus an extracted dir; only `.zip` yields a `PackageId`.
- **No duplicate root for `$GOCACHE`** on default paths: it's under `~/Library/Caches` or `~/.cache` (both already roots). Same SwiftPM fix — `is_ancestor_or_descendant` filter keeps TreeNodes unique. Explicit non-default `$GOCACHE` paths outside existing roots do get added.
- **New `pre_delete` hook**: architectural extension point, not a Go-specific kludge. Default no-op. Future providers needing custodial filesystem setup (xattr strip, watcher pause, file-handle release) now have a clean seam.

## What changed

- `src/tree/node.rs` — `CacheKind::Go` with label/description/url.
- `src/providers/go_mod.rs` — **new** provider. Includes `decode_module_path`, `parse_download_zip`, `parse_extracted_module_dir`, `pre_delete` + Unix `chmod_plus_w_recursive`.
- `src/providers/mod.rs` — dispatch arms for detect, semantic_name, metadata, package_id, upgrade_command, safety, pre_delete.
- `src/security/registry.rs` — `parse_go_proxy_list` + `is_go_pseudo_version` + `encode_go_module_path`; Go arm in `build_registry_url` / `parse_registry_response`.
- `src/config.rs` — `probe_go_paths()` (GOMODCACHE env → `go env GOMODCACHE` → `~/go/pkg/mod` fallback); subsumed-root filter for `$GOCACHE`.
- `src/app.rs::perform_delete` — calls `providers::pre_delete` before `remove_dir_all`; hook errors count as `errored`.
- `tests/integration_go.rs` — **new** Tier-2 pipeline tests (synthetic fixtures, bang-decoding, dedup, build-cache, pre_delete).
- `tests/e2e_go_provider.rs` — **new** Tier-3 real-tool E2E: `go mod download github.com/gin-gonic/gin@v1.6.0` → scanner → OSV (CVE-2023-26125 et al.) → proxy.golang.org → pre_delete + remove_dir_all. All scoped to `<tempdir>/pkg/mod` via `GOMODCACHE`/`GOCACHE`/`GOPATH` env vars.
- `README.md`, `CHANGELOG.md`, `docs/user-guide.md`, `docs/adding-a-provider.md`, `TODO.md` — docs.

## Test plan

- [x] `cargo test` — 1973 passed
- [x] `cargo test --features mcp` — all passing
- [x] `cargo test --features e2e --test e2e_go_provider` — passes on a real `go` install (hits osv.dev + proxy.golang.org)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] L1 confusable-suffix guards (`pkg/mod-backup`, `go-build-backup`)
- [x] L2 non-ASCII module paths (`café`)
- [x] L3 pre-release version comparison
- [x] L9 dedup canonical (`.zip` only)
- [x] pre_delete default `Ok(())` verified for every non-Go `CacheKind` via exhaustive regression test
- [x] Manual smoke: ran the binary against the existing `~/go/pkg/mod` on this machine — module names decoded correctly, safety icons correct, detail panel shows module cache label.

## Design spec

`docs/superpowers/specs/2026-04-21-go-provider-design.md` (included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)