### PR TITLE
Add Poetry (pypoetry) cache provider

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -38,6 +38,7 @@ fn canonical_ecosystem(s: &str) -> Option<&'static str> {
         "npm" | "npx" | "node" | "nodejs" => Some("npm"),
         "pip" | "pypi" | "python" => Some("pip"),
         "uv" => Some("uv"),
+        "poetry" => Some("poetry"),
         "cargo" | "crates" | "crates.io" | "rust" => Some("cargo"),
         "homebrew" | "brew" => Some("homebrew"),
         s if s.contains("huggingface") => Some("huggingface"),
@@ -61,16 +62,15 @@ fn matches_ecosystem(label: &str, filter: &str) -> bool {
     }
     // Try canonical match first (handles both vocabularies)
     if let (Some(cl), Some(cf)) = (canonical_ecosystem(label), canonical_ecosystem(filter)) {
-        // pip and uv are both Python — match either when user says "python" or "pypi"
-        let python_group = |c: &str| c == "pip" || c == "uv";
+        // pip, uv, and Poetry share the PyPI ecosystem for vulnerability data.
+        let python_group = |c: &str| c == "pip" || c == "uv" || c == "poetry";
         if cl == cf {
             return true;
         }
         if python_group(cl) && python_group(cf) {
-            return canonical_ecosystem(filter) == Some("pip")
-                || canonical_ecosystem(filter) == Some("uv");
+            return true;
         }
-        // "python"/"pypi" should match both pip and uv
+        // "python"/"pypi" should match pip, uv, and Poetry caches
         if cf == "pip" && python_group(cl) {
             return true;
         }
@@ -1202,6 +1202,8 @@ mod tests {
         assert!(matches_ecosystem("pip", "pypi"));
         assert!(matches_ecosystem("uv", "python"));
         assert!(matches_ecosystem("uv", "pypi"));
+        assert!(matches_ecosystem("Poetry", "poetry"));
+        assert!(matches_ecosystem("Poetry", "pypi"));
         assert!(matches_ecosystem("Cargo", "rust"));
         assert!(matches_ecosystem("Cargo", "crates"));
         assert!(matches_ecosystem("Homebrew", "brew"));

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -11,6 +11,7 @@ pub mod maven;
 pub mod npm;
 pub mod pip;
 pub mod pnpm;
+pub mod poetry;
 pub mod pre_commit;
 pub mod prisma;
 pub mod swiftpm;
@@ -66,6 +67,7 @@ pub fn detect(path: &Path) -> CacheKind {
     match name.as_str() {
         "huggingface" => return CacheKind::HuggingFace,
         "pip" => return CacheKind::Pip,
+        "pypoetry" => return CacheKind::Poetry,
         "uv" => return CacheKind::Uv,
         "Homebrew" => return CacheKind::Homebrew,
         "pre-commit" => return CacheKind::PreCommit,
@@ -125,6 +127,7 @@ pub fn detect(path: &Path) -> CacheKind {
             ".bun" => return CacheKind::Bun,
             "huggingface" => return CacheKind::HuggingFace,
             "pip" => return CacheKind::Pip,
+            "pypoetry" => return CacheKind::Poetry,
             "uv" => return CacheKind::Uv,
             "Homebrew" => return CacheKind::Homebrew,
             "pre-commit" => return CacheKind::PreCommit,
@@ -172,6 +175,7 @@ pub fn semantic_name(kind: CacheKind, path: &Path) -> Option<String> {
     match kind {
         CacheKind::HuggingFace => huggingface::semantic_name(path),
         CacheKind::Pip => pip::semantic_name(path),
+        CacheKind::Poetry => poetry::semantic_name(path),
         CacheKind::Uv => uv::semantic_name(path),
         CacheKind::Npm => npm::semantic_name(path),
         CacheKind::Homebrew => homebrew::semantic_name(path),
@@ -199,6 +203,7 @@ pub fn metadata(kind: CacheKind, path: &Path) -> Vec<MetadataField> {
     match kind {
         CacheKind::HuggingFace => huggingface::metadata(path),
         CacheKind::Pip => pip::metadata(path),
+        CacheKind::Poetry => poetry::metadata(path),
         CacheKind::Uv => uv::metadata(path),
         CacheKind::Npm => npm::metadata(path),
         CacheKind::Homebrew => homebrew::metadata(path),
@@ -232,6 +237,7 @@ pub fn package_id(kind: CacheKind, path: &Path) -> Option<PackageId> {
     match kind {
         CacheKind::Uv => uv::package_id(path),
         CacheKind::Pip => pip::package_id(path),
+        CacheKind::Poetry => poetry::package_id(path),
         CacheKind::Npm => npm::package_id(path),
         CacheKind::Cargo => cargo::package_id(path),
         CacheKind::Yarn => yarn::package_id(path),
@@ -268,6 +274,7 @@ pub fn upgrade_command(kind: CacheKind, name: &str, version: &str) -> Option<Str
     }
     match kind {
         CacheKind::Pip => Some(format!("pip install '{name}>={version}'")),
+        CacheKind::Poetry => Some(format!("poetry add '{name}>={version}'")),
         CacheKind::Uv => Some(format!("uv pip install '{name}>={version}'")),
         CacheKind::Npm => Some(format!("npm install {name}@{version}")),
         CacheKind::Cargo => Some(format!("cargo update -p {name}")),
@@ -325,9 +332,30 @@ fn has_adjacent_components(path: &Path, first: &str, second: &str) -> bool {
         .any(|w| w[0] == first && w[1] == second)
 }
 
+/// Safety for Poetry cache paths under `pypoetry/` (issue #21).
+fn poetry_safety(path: &Path) -> SafetyLevel {
+    let comps: Vec<&std::ffi::OsStr> = path.components().map(|c| c.as_os_str()).collect();
+    let Some(pi) = comps.iter().position(|&c| c == "pypoetry") else {
+        return SafetyLevel::Safe;
+    };
+    if comps.iter().skip(pi + 1).any(|&c| c == "virtualenvs") {
+        return SafetyLevel::Caution;
+    }
+    if comps.iter().skip(pi + 1).any(|&c| c == "artifacts") {
+        return SafetyLevel::Safe;
+    }
+    for i in (pi + 1)..comps.len().saturating_sub(1) {
+        if comps[i] == "cache" && comps[i + 1] == "repositories" {
+            return SafetyLevel::Safe;
+        }
+    }
+    SafetyLevel::Caution
+}
+
 /// Get safety level for deletion.
 pub fn safety(kind: CacheKind, path: &Path) -> SafetyLevel {
     match kind {
+        CacheKind::Poetry => poetry_safety(path),
         CacheKind::Pnpm => {
             if path.to_string_lossy().contains("node_modules/.pnpm") {
                 SafetyLevel::Caution
@@ -468,6 +496,52 @@ mod tests {
         assert_eq!(
             detect(&PathBuf::from("/home/user/.cache/uv")),
             CacheKind::Uv
+        );
+    }
+
+    #[test]
+    fn detect_pypoetry_xdg_cache() {
+        assert_eq!(
+            detect(&PathBuf::from("/home/user/.cache/pypoetry")),
+            CacheKind::Poetry
+        );
+    }
+
+    #[test]
+    fn detect_pypoetry_macos_library_caches() {
+        assert_eq!(
+            detect(&PathBuf::from("/Users/me/Library/Caches/pypoetry")),
+            CacheKind::Poetry
+        );
+    }
+
+    #[test]
+    fn detect_pypoetry_artifacts_subdir() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.cache/pypoetry/artifacts/ab/cd/pkg-1.0.0-py3-none-any.whl"
+            )),
+            CacheKind::Poetry
+        );
+    }
+
+    #[test]
+    fn detect_pypoetry_virtualenvs_subdir() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/Users/me/Library/Caches/pypoetry/virtualenvs/myproj-sOaFvs2V-py3.12"
+            )),
+            CacheKind::Poetry
+        );
+    }
+
+    #[test]
+    fn detect_pypoetry_cache_repositories() {
+        assert_eq!(
+            detect(&PathBuf::from(
+                "/home/user/.cache/pypoetry/cache/repositories/pypi"
+            )),
+            CacheKind::Poetry
         );
     }
 
@@ -728,6 +802,50 @@ mod tests {
     }
 
     #[test]
+    fn safety_poetry_virtualenvs_is_caution() {
+        assert_eq!(
+            safety(
+                CacheKind::Poetry,
+                &PathBuf::from("/Users/me/Library/Caches/pypoetry/virtualenvs/foo-py3.12")
+            ),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
+    fn safety_poetry_artifacts_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Poetry,
+                &PathBuf::from("/home/user/.cache/pypoetry/artifacts/ab/wheel.whl")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_poetry_cache_repositories_is_safe() {
+        assert_eq!(
+            safety(
+                CacheKind::Poetry,
+                &PathBuf::from("/home/user/.cache/pypoetry/cache/repositories/pypi")
+            ),
+            SafetyLevel::Safe
+        );
+    }
+
+    #[test]
+    fn safety_poetry_virtualenvs_suffix_is_not_virtualenvs_bucket() {
+        assert_eq!(
+            safety(
+                CacheKind::Poetry,
+                &PathBuf::from("/home/user/.cache/pypoetry/virtualenvs-backup/old")
+            ),
+            SafetyLevel::Caution
+        );
+    }
+
+    #[test]
     fn safety_pnpm_virtual_store_is_caution() {
         assert_eq!(
             safety(
@@ -802,6 +920,14 @@ mod tests {
         assert_eq!(
             upgrade_command(CacheKind::Uv, "flask", "3.1.0"),
             Some("uv pip install 'flask>=3.1.0'".to_string())
+        );
+    }
+
+    #[test]
+    fn upgrade_command_poetry() {
+        assert_eq!(
+            upgrade_command(CacheKind::Poetry, "requests", "2.32.0"),
+            Some("poetry add 'requests>=2.32.0'".to_string())
         );
     }
 
@@ -1431,6 +1557,7 @@ mod tests {
         let all = [
             CacheKind::HuggingFace,
             CacheKind::Pip,
+            CacheKind::Poetry,
             CacheKind::Uv,
             CacheKind::Npm,
             CacheKind::Homebrew,
@@ -1448,6 +1575,7 @@ mod tests {
             CacheKind::Gradle,
             CacheKind::SwiftPm,
             CacheKind::Xcode,
+            CacheKind::Go,
             CacheKind::Unknown,
         ];
         for kind in &all {

--- a/src/providers/poetry.rs
+++ b/src/providers/poetry.rs
@@ -1,0 +1,253 @@
+use super::MetadataField;
+use std::path::Path;
+
+/// True when `path` is under a Poetry cache root (`.../pypoetry/...`).
+fn is_under_pypoetry(path: &Path) -> bool {
+    path.components().any(|c| c.as_os_str() == "pypoetry")
+}
+
+pub fn semantic_name(path: &Path) -> Option<String> {
+    if !is_under_pypoetry(path) {
+        return None;
+    }
+
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    if matches!(name.as_str(), "artifacts" | "cache" | "virtualenvs") {
+        return None;
+    }
+
+    if name.ends_with(".whl") {
+        let parts: Vec<&str> = name.splitn(3, '-').collect();
+        if parts.len() >= 2 {
+            return Some(format!("{} {}", parts[0], parts[1]));
+        }
+    }
+
+    if let Some(stem) = name.strip_suffix(".tar.gz")
+        && let Some((pkg, ver)) = parse_sdist_stem(stem)
+    {
+        return Some(format!("{pkg} {ver}"));
+    }
+
+    None
+}
+
+/// Parse `distribution-version` from an sdist filename stem (without `.tar.gz`).
+fn parse_sdist_stem(stem: &str) -> Option<(String, String)> {
+    let (pkg, ver) = stem.rsplit_once('-')?;
+    if pkg.is_empty() || ver.is_empty() {
+        return None;
+    }
+    // Version should start with a digit (PEP 440 / common sdist layout).
+    if !ver
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_digit() || c == 'v')
+    {
+        return None;
+    }
+    Some((pkg.replace('_', "-"), ver.to_string()))
+}
+
+pub fn package_id(path: &Path) -> Option<super::PackageId> {
+    if !is_under_pypoetry(path) {
+        return None;
+    }
+
+    let name = path.file_name()?.to_string_lossy().to_string();
+
+    if name.ends_with(".whl") {
+        let parts: Vec<&str> = name.splitn(3, '-').collect();
+        if parts.len() >= 2 {
+            return Some(super::PackageId {
+                ecosystem: "PyPI",
+                name: parts[0].replace('_', "-").to_lowercase(),
+                version: parts[1].to_string(),
+            });
+        }
+    }
+
+    if let Some(stem) = name.strip_suffix(".tar.gz")
+        && let Some((pkg, ver)) = parse_sdist_stem(stem)
+    {
+        return Some(super::PackageId {
+            ecosystem: "PyPI",
+            name: pkg.to_lowercase(),
+            version: ver,
+        });
+    }
+
+    None
+}
+
+fn count_artifacts(path: &Path) -> (usize, usize) {
+    let mut wheels = 0usize;
+    let mut sdists = 0usize;
+    for entry in jwalk::WalkDir::new(path)
+        .skip_hidden(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let p = entry.path();
+        if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
+            match ext {
+                "whl" => wheels += 1,
+                "gz" if p.to_string_lossy().ends_with(".tar.gz") => sdists += 1,
+                _ => {}
+            }
+        }
+    }
+    (wheels, sdists)
+}
+
+pub fn metadata(path: &Path) -> Vec<MetadataField> {
+    let mut fields = Vec::new();
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    match name.as_str() {
+        "artifacts" => {
+            fields.push(MetadataField {
+                label: "Contents".to_string(),
+                value: "Downloaded wheels and source distributions (.whl, .tar.gz)".to_string(),
+            });
+            let (wheels, sdists) = count_artifacts(path);
+            let total = wheels + sdists;
+            if total > 0 {
+                fields.push(MetadataField {
+                    label: "Packages".to_string(),
+                    value: total.to_string(),
+                });
+            }
+        }
+        "repositories" => {
+            fields.push(MetadataField {
+                label: "Contents".to_string(),
+                value: "PyPI simple / repository index cache".to_string(),
+            });
+        }
+        "virtualenvs" => {
+            fields.push(MetadataField {
+                label: "Contents".to_string(),
+                value: "Poetry-managed virtual environments (recreated on poetry install)"
+                    .to_string(),
+            });
+        }
+        _ => {}
+    }
+
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn semantic_name_wheel_under_artifacts() {
+        let p = PathBuf::from(
+            "/home/user/.cache/pypoetry/artifacts/ab/requests-2.31.0-py3-none-any.whl",
+        );
+        assert_eq!(semantic_name(&p), Some("requests 2.31.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_sdist_under_artifacts() {
+        let p = PathBuf::from("/home/user/.cache/pypoetry/artifacts/xx/requests-2.31.0.tar.gz");
+        assert_eq!(semantic_name(&p), Some("requests 2.31.0".into()));
+    }
+
+    #[test]
+    fn semantic_name_sdist_with_hyphenated_name() {
+        let p =
+            PathBuf::from("/home/user/.cache/pypoetry/artifacts/xx/opencv-python-4.5.5.64.tar.gz");
+        assert_eq!(semantic_name(&p), Some("opencv-python 4.5.5.64".into()));
+    }
+
+    #[test]
+    fn semantic_name_returns_none_for_bucket_dirs() {
+        assert_eq!(
+            semantic_name(&PathBuf::from("/.cache/pypoetry/artifacts")),
+            None
+        );
+        assert_eq!(
+            semantic_name(&PathBuf::from("/.cache/pypoetry/cache")),
+            None
+        );
+        assert_eq!(
+            semantic_name(&PathBuf::from("/.cache/pypoetry/virtualenvs")),
+            None
+        );
+    }
+
+    #[test]
+    fn semantic_name_returns_none_outside_pypoetry() {
+        let p = PathBuf::from("/tmp/requests-2.31.0-py3-none-any.whl");
+        assert_eq!(semantic_name(&p), None);
+    }
+
+    #[test]
+    fn package_id_from_wheel() {
+        let p = PathBuf::from(
+            "/Library/Caches/pypoetry/artifacts/z/Django_REST_framework-3.14.0-py3-none-any.whl",
+        );
+        let id = package_id(&p).unwrap();
+        assert_eq!(id.ecosystem, "PyPI");
+        assert_eq!(id.name, "django-rest-framework");
+        assert_eq!(id.version, "3.14.0");
+    }
+
+    #[test]
+    fn package_id_from_sdist() {
+        let p = PathBuf::from("/home/user/.cache/pypoetry/artifacts/a/my_pkg-1.2.3.tar.gz");
+        let id = package_id(&p).unwrap();
+        assert_eq!(id.ecosystem, "PyPI");
+        assert_eq!(id.name, "my-pkg");
+        assert_eq!(id.version, "1.2.3");
+    }
+
+    #[test]
+    fn package_id_none_outside_pypoetry() {
+        assert!(package_id(&PathBuf::from("/tmp/pkg-1.0.0-py3-none-any.whl")).is_none());
+    }
+
+    #[test]
+    fn metadata_artifacts_counts_wheels_and_sdist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("pypoetry").join("artifacts");
+        std::fs::create_dir_all(artifacts.join("sub/a")).unwrap();
+        std::fs::write(artifacts.join("sub/a/p-1.0.0-py3.whl"), "").unwrap();
+        std::fs::write(artifacts.join("sub/a/q-2.0.0.tar.gz"), "").unwrap();
+        std::fs::write(artifacts.join("ignored.txt"), "").unwrap();
+
+        let fields = metadata(&artifacts);
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[1].label, "Packages");
+        assert_eq!(fields[1].value, "2");
+    }
+
+    #[test]
+    fn metadata_repositories_dir() {
+        let p = PathBuf::from("/home/u/Library/Caches/pypoetry/cache/repositories");
+        let fields = metadata(&p);
+        assert_eq!(fields.len(), 1);
+        assert!(fields[0].value.contains("PyPI") || fields[0].value.contains("index"));
+    }
+
+    #[test]
+    fn metadata_virtualenvs_dir() {
+        let p = PathBuf::from("/home/u/Library/Caches/pypoetry/virtualenvs");
+        let fields = metadata(&p);
+        assert_eq!(fields.len(), 1);
+        assert!(fields[0].value.contains("virtual") || fields[0].value.contains("Poetry"));
+    }
+
+    #[test]
+    fn metadata_unknown_name_returns_empty() {
+        assert!(metadata(&PathBuf::from("/cache/pypoetry/weird")).is_empty());
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -342,4 +342,24 @@ mod tests {
         // Should log, not panic
         send_result(&tx, ScanResult::RootsScanned(vec![]));
     }
+
+    #[test]
+    fn discover_packages_dedup_poetry_same_wheel_two_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("pypoetry").join("artifacts");
+        let p1 = base.join("aa").join("11");
+        let p2 = base.join("bb").join("22");
+        std::fs::create_dir_all(&p1).unwrap();
+        std::fs::create_dir_all(&p2).unwrap();
+        let w = "requests-2.31.0-py3-none-any.whl";
+        std::fs::write(p1.join(w), "").unwrap();
+        std::fs::write(p2.join(w), "").unwrap();
+        let roots = vec![tmp.path().to_path_buf()];
+        let packs = discover_packages(&roots);
+        assert_eq!(
+            packs.len(),
+            1,
+            "same PyPI (name, version) from two artifact paths should dedup: {packs:?}"
+        );
+    }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -5,6 +5,7 @@ use std::time::SystemTime;
 pub enum CacheKind {
     HuggingFace,
     Pip,
+    Poetry,
     Uv,
     Npm,
     Homebrew,
@@ -32,6 +33,7 @@ impl CacheKind {
         match self {
             Self::HuggingFace => "HuggingFace Hub",
             Self::Pip => "pip",
+            Self::Poetry => "Poetry",
             Self::Uv => "uv",
             Self::Npm => "npm",
             Self::Homebrew => "Homebrew",
@@ -58,6 +60,9 @@ impl CacheKind {
         match self {
             Self::HuggingFace => "ML model hub — cached models, datasets, and spaces",
             Self::Pip => "Python package installer — cached wheels and HTTP responses",
+            Self::Poetry => {
+                "Poetry — cached wheels, sdists, repository metadata, and managed virtualenvs"
+            }
             Self::Uv => "Fast Python package manager — cached archives and built wheels",
             Self::Npm => "Node.js package manager — content-addressable package cache",
             Self::Homebrew => "macOS package manager — downloaded bottles and cask installers",
@@ -88,6 +93,7 @@ impl CacheKind {
         match self {
             Self::HuggingFace => "https://huggingface.co",
             Self::Pip => "https://pip.pypa.io",
+            Self::Poetry => "https://python-poetry.org",
             Self::Uv => "https://github.com/astral-sh/uv",
             Self::Npm => "https://www.npmjs.com",
             Self::Homebrew => "https://brew.sh",
@@ -209,6 +215,7 @@ mod tests {
         let kinds = [
             CacheKind::HuggingFace,
             CacheKind::Pip,
+            CacheKind::Poetry,
             CacheKind::Uv,
             CacheKind::Npm,
             CacheKind::Homebrew,
@@ -245,6 +252,7 @@ mod tests {
         let all = [
             CacheKind::HuggingFace,
             CacheKind::Pip,
+            CacheKind::Poetry,
             CacheKind::Uv,
             CacheKind::Npm,
             CacheKind::Homebrew,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -993,7 +993,7 @@ fn scanner_expand_bun_cache_shows_semantic_names() {
             // so semantic_name returns None and the raw scope name is used.
             // Their actual packages (@types/node, @babel/core) are nested inside.
             assert!(
-                names.iter().any(|n| *n == "@types"),
+                names.contains(&"@types"),
                 "Should show '@types' scope dir: {:?}",
                 names
             );


### PR DESCRIPTION
## Summary

Implements [issue #21](https://github.com/juliensimon/cache-commander/issues/21): Poetry (`pypoetry`) cache provider.

### Changes
- **`src/providers/poetry.rs`**: `semantic_name` / `package_id` for `.whl` and `.tar.gz` under `pypoetry`; `metadata` for `artifacts`, `repositories`, `virtualenvs`.
- **`src/providers/mod.rs`**: `detect` for `pypoetry`; `poetry_safety` (artifacts + `cache/repositories` → Safe, `virtualenvs` → Caution; avoids `virtualenvs-backup` false positive); dispatch + `upgrade_command` (`poetry add 'pkg>=ver'`).
- **`src/tree/node.rs`**: `CacheKind::Poetry` label, description, URL.
- **`src/mcp/mod.rs`**: Ecosystem filter treats Poetry with pip/uv for `pypi` / `python`.
- **`src/scanner/mod.rs`**: Dedup test for identical wheel at two artifact paths.
- **`tests/integration.rs`**: Clippy `manual_contains` fix (required for pre-commit).

### Verification
- `cargo test` and `cargo clippy --all-targets -- -D warnings` pass locally.